### PR TITLE
fix: use logged-in user's OIDC token for MP API calls

### DIFF
--- a/src/components/contact-logs/actions.ts
+++ b/src/components/contact-logs/actions.ts
@@ -13,7 +13,7 @@ export async function getContactLogTypes(): Promise<ContactLogTypes[]> {
       throw new Error("Authentication required");
     }
 
-    const contactLogService = await ContactLogService.getInstance();
+    const contactLogService = await ContactLogService.getInstance(session.accessToken);
     const types = await contactLogService.getContactLogTypes();
     
     return types;
@@ -44,8 +44,8 @@ export async function createContactLog(
       // Fallback: Fetch user profile using User_GUID
       console.log("User profile not in session, fetching from MP...");
       const { MPHelper } = await import("@/lib/providers/ministry-platform");
-      const mp = new MPHelper();
-      
+      const mp = new MPHelper({ accessToken: session.accessToken });
+
       const users = await mp.getTableRecords<{ User_ID: number }>({
         table: "dp_Users",
         filter: `User_GUID = '${session.user.id}'`,
@@ -73,7 +73,7 @@ export async function createContactLog(
 
     console.log("createContactLog action - Creating with data:", JSON.stringify(logDataWithUser, null, 2));
     
-    const contactLogService = await ContactLogService.getInstance();
+    const contactLogService = await ContactLogService.getInstance(session.accessToken);
     const contactLog = await contactLogService.createContactLog(logDataWithUser);
     
     console.log("createContactLog action - Successfully created");
@@ -103,8 +103,8 @@ export async function updateContactLog(
       // Fallback: Fetch user profile using User_GUID
       console.log("User profile not in session, fetching from MP...");
       const { MPHelper } = await import("@/lib/providers/ministry-platform");
-      const mp = new MPHelper();
-      
+      const mp = new MPHelper({ accessToken: session.accessToken });
+
       const users = await mp.getTableRecords<{ User_ID: number }>({
         table: "dp_Users",
         filter: `User_GUID = '${session.user.id}'`,
@@ -132,7 +132,7 @@ export async function updateContactLog(
     console.log("updateContactLog action - Updating log:", contactLogId);
     console.log("updateContactLog action - Update data:", JSON.stringify(logDataWithUser, null, 2));
     
-    const contactLogService = await ContactLogService.getInstance();
+    const contactLogService = await ContactLogService.getInstance(session.accessToken);
     const contactLog = await contactLogService.updateContactLog(contactLogId, logDataWithUser);
     
     console.log("updateContactLog action - Successfully updated");
@@ -156,7 +156,7 @@ export async function deleteContactLog(contactLogId: number): Promise<void> {
 
     console.log("deleteContactLog action - Deleting log:", contactLogId);
     
-    const contactLogService = await ContactLogService.getInstance();
+    const contactLogService = await ContactLogService.getInstance(session.accessToken);
     await contactLogService.deleteContactLog(contactLogId);
     
     console.log("deleteContactLog action - Successfully deleted");
@@ -177,7 +177,7 @@ export async function getContactLogsByContactId(contactId: number): Promise<Cont
       throw new Error("Valid contact ID is required");
     }
 
-    const contactLogService = await ContactLogService.getInstance();
+    const contactLogService = await ContactLogService.getInstance(session.accessToken);
     const results = await contactLogService.getContactLogsByContactId(contactId);
     
     return results;
@@ -198,7 +198,7 @@ export async function getContactLogById(contactLogId: number): Promise<ContactLo
       throw new Error("Valid contact log ID is required");
     }
 
-    const contactLogService = await ContactLogService.getInstance();
+    const contactLogService = await ContactLogService.getInstance(session.accessToken);
     const result = await contactLogService.getContactLogById(contactLogId);
     
     return result;

--- a/src/components/contact-lookup-details/actions.ts
+++ b/src/components/contact-lookup-details/actions.ts
@@ -1,22 +1,28 @@
 'use server';
 
+import { auth } from '@/auth';
 import { ContactLookupDetails, ContactLogDisplay } from '@/lib/dto';
 import { ContactService } from '@/services/contactService';
 import { ContactLogService } from '@/services/contactLogService';
 
 export async function getContactDetails(guid: string): Promise<ContactLookupDetails> {
   try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      throw new Error("Authentication required");
+    }
+
     if (!guid || guid.trim().length === 0) {
       throw new Error('GUID is required');
     }
 
-    const contactService = await ContactService.getInstance();
+    const contactService = await ContactService.getInstance(session.accessToken);
     const contact = await contactService.getContactByGuid(guid.trim());
-    
+
     if (!contact) {
       throw new Error('Contact not found');
     }
-    
+
     return contact;
   } catch (error) {
     console.error('Error fetching contact details:', error);
@@ -26,31 +32,36 @@ export async function getContactDetails(guid: string): Promise<ContactLookupDeta
 
 export async function getContactLogsByContactId(contactId: number): Promise<ContactLogDisplay[]> {
   try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      throw new Error("Authentication required");
+    }
+
     if (!contactId || contactId <= 0) {
       throw new Error('Valid contact ID is required');
     }
 
-    const contactLogService = await ContactLogService.getInstance();
+    const contactLogService = await ContactLogService.getInstance(session.accessToken);
     const logs = await contactLogService.getContactLogsByContactId(contactId);
-    
+
     // Transform to ContactLogDisplay with type information
     const logsWithTypes = await Promise.all(
       logs.map(async (log) => {
         let contactLogType: string | null = null;
-        
+
         if (log.Contact_Log_Type_ID) {
           const types = await contactLogService.getContactLogTypes();
           const type = types.find(t => t.Contact_Log_Type_ID === log.Contact_Log_Type_ID);
           contactLogType = type?.Contact_Log_Type || null;
         }
-        
+
         return {
           ...log,
           Contact_Log_Type: contactLogType,
         } as ContactLogDisplay;
       })
     );
-    
+
     return logsWithTypes;
   } catch (error) {
     console.error('Error fetching contact logs:', error);

--- a/src/components/contact-lookup/actions.ts
+++ b/src/components/contact-lookup/actions.ts
@@ -1,17 +1,23 @@
 'use server';
 
+import { auth } from '@/auth';
 import { ContactService } from '@/services/contactService';
 import { ContactSearch } from '@/lib/dto';
 
 export async function searchContacts(searchTerm: string): Promise<ContactSearch[]> {
   try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      throw new Error("Authentication required");
+    }
+
     if (!searchTerm || searchTerm.trim().length === 0) {
       return [];
     }
 
-    const contactService = await ContactService.getInstance();
+    const contactService = await ContactService.getInstance(session.accessToken);
     const results = await contactService.contactSearch(searchTerm.trim());
-    
+
     return results;
   } catch (error) {
     console.error('Error searching contacts:', error);

--- a/src/components/shared-actions/user.ts
+++ b/src/components/shared-actions/user.ts
@@ -1,15 +1,17 @@
 'use server';
 
+import { auth } from "@/auth";
 import { MPUserProfile } from "@/lib/providers/ministry-platform/types";
 import { UserService } from '@/services/userService';
 
 /**
  * Fetches the current user's profile from Ministry Platform
- * @param id - The user's contact ID
+ * @param id - The user's GUID
  * @returns The user's profile data
  */
 export async function getCurrentUserProfile(id: string): Promise<MPUserProfile> {
-  const userService = await UserService.getInstance();
+  const session = await auth();
+  const userService = await UserService.getInstance(session?.accessToken);
   const userProfile = await userService.getUserProfile(id);
   return userProfile;
 }

--- a/src/components/user-tools-debug/actions.ts
+++ b/src/components/user-tools-debug/actions.ts
@@ -7,30 +7,30 @@ import { MPUserProfile } from "@/lib/providers/ministry-platform/types";
 
 export async function getUserTools(): Promise<string[]> {
   const session = await auth();
-  
+
   if (!session?.userProfile?.User_GUID) {
     throw new Error("Unauthorized - Missing user session data");
   }
 
   let userId = session.userProfile.User_ID;
-  
+
   if (!userId) {
-    const mp = new MPHelper();
+    const mp = new MPHelper({ accessToken: session.accessToken });
     const records = await mp.getTableRecords<MPUserProfile>({
       table: "dp_Users",
       filter: `User_GUID = '${session.userProfile.User_GUID}'`,
       select: "User_ID",
       top: 1
     });
-    
+
     if (!records || records.length === 0) {
       throw new Error("User not found");
     }
-    
+
     userId = records[0].User_ID;
   }
 
-  const toolService = await ToolService.getInstance();
+  const toolService = await ToolService.getInstance(session.accessToken);
   const toolPaths = await toolService.getUserTools(1, userId);
 
   return toolPaths;

--- a/src/components/volunteer-processing/actions.ts
+++ b/src/components/volunteer-processing/actions.ts
@@ -11,7 +11,7 @@ export async function getInProcessVolunteers(): Promise<VolunteerCard[]> {
       throw new Error("Authentication required");
     }
 
-    const service = await VolunteerService.getInstance();
+    const service = await VolunteerService.getInstance(session.accessToken);
     return await service.getInProcessVolunteers();
   } catch (error) {
     console.error("Error fetching in-process volunteers:", error);
@@ -26,7 +26,7 @@ export async function getApprovedVolunteers(): Promise<ApprovedVolunteersResult>
       throw new Error("Authentication required");
     }
 
-    const service = await VolunteerService.getInstance();
+    const service = await VolunteerService.getInstance(session.accessToken);
     return await service.getApprovedVolunteers();
   } catch (error) {
     console.error("Error fetching approved volunteers:", error);
@@ -45,7 +45,7 @@ export async function getVolunteerDetail(
       throw new Error("Authentication required");
     }
 
-    const service = await VolunteerService.getInstance();
+    const service = await VolunteerService.getInstance(session.accessToken);
     return await service.getVolunteerDetail(contactId, participantId, groupParticipantId);
   } catch (error) {
     console.error("Error fetching volunteer detail:", error);
@@ -60,7 +60,7 @@ export async function getMilestoneFiles(milestoneRecordId: number): Promise<Mile
       throw new Error("Authentication required");
     }
 
-    const service = await VolunteerService.getInstance();
+    const service = await VolunteerService.getInstance(session.accessToken);
     return await service.getMilestoneFiles(milestoneRecordId);
   } catch (error) {
     console.error("Error fetching milestone files:", error);
@@ -75,7 +75,7 @@ export async function getCertificationFiles(certificationRecordId: number): Prom
       throw new Error("Authentication required");
     }
 
-    const service = await VolunteerService.getInstance();
+    const service = await VolunteerService.getInstance(session.accessToken);
     return await service.getCertificationFiles(certificationRecordId);
   } catch (error) {
     console.error("Error fetching certification files:", error);
@@ -90,7 +90,7 @@ export async function getFormResponseFiles(formResponseId: number): Promise<Mile
       throw new Error("Authentication required");
     }
 
-    const service = await VolunteerService.getInstance();
+    const service = await VolunteerService.getInstance(session.accessToken);
     return await service.getFormResponseFiles(formResponseId);
   } catch (error) {
     console.error("Error fetching form response files:", error);
@@ -110,7 +110,7 @@ export async function createFormResponse(formData: FormData): Promise<void> {
       userId = session.userProfile.User_ID;
     }
 
-    const service = await VolunteerService.getInstance();
+    const service = await VolunteerService.getInstance(session.accessToken);
     const newFormResponseId = await service.createFormResponse({
       Form_ID: Number(formData.get("Form_ID")),
       Contact_ID: Number(formData.get("Contact_ID")),
@@ -161,7 +161,7 @@ export async function uploadVolunteerPhoto(formData: FormData): Promise<{ succes
       userId = session.userProfile.User_ID;
     }
 
-    const service = await VolunteerService.getInstance();
+    const service = await VolunteerService.getInstance(session.accessToken);
     await service.uploadContactPhoto(contactId, file, userId);
     return { success: true };
   } catch (error) {
@@ -182,7 +182,7 @@ export async function createVolunteerMilestone(formData: FormData): Promise<void
       userId = session.userProfile.User_ID;
     }
 
-    const service = await VolunteerService.getInstance();
+    const service = await VolunteerService.getInstance(session.accessToken);
     const newMilestoneId = await service.createMilestone({
       Participant_ID: Number(formData.get("Participant_ID")),
       Milestone_ID: Number(formData.get("Milestone_ID")),
@@ -225,7 +225,7 @@ export async function updateVolunteerMilestone(formData: FormData): Promise<{ su
       userId = session.userProfile.User_ID;
     }
 
-    const service = await VolunteerService.getInstance();
+    const service = await VolunteerService.getInstance(session.accessToken);
     await service.updateMilestone({
       Participant_Milestone_ID: milestoneRecordId,
       Date_Accomplished: formData.get("Date_Accomplished") as string || undefined,
@@ -268,7 +268,7 @@ export async function updateVolunteerCertification(formData: FormData): Promise<
       userId = session.userProfile.User_ID;
     }
 
-    const service = await VolunteerService.getInstance();
+    const service = await VolunteerService.getInstance(session.accessToken);
     await service.updateCertification({
       Participant_Certification_ID: certId,
       Certification_Completed: formData.get("Certification_Completed") as string || undefined,
@@ -311,7 +311,7 @@ export async function updateVolunteerFormResponse(formData: FormData): Promise<{
       userId = session.userProfile.User_ID;
     }
 
-    const service = await VolunteerService.getInstance();
+    const service = await VolunteerService.getInstance(session.accessToken);
     await service.updateFormResponse({
       Form_Response_ID: frId,
       Response_Date: formData.get("Response_Date") as string || undefined,
@@ -343,7 +343,7 @@ export async function getApprovedGroupRoles(): Promise<GroupRoleOption[]> {
       throw new Error("Authentication required");
     }
 
-    const service = await VolunteerService.getInstance();
+    const service = await VolunteerService.getInstance(session.accessToken);
     return await service.getApprovedGroupRoles();
   } catch (error) {
     console.error("Error fetching approved group roles:", error);
@@ -358,7 +358,7 @@ export async function getApprovedGroupsList(): Promise<GroupFilterOption[]> {
       throw new Error("Authentication required");
     }
 
-    const service = await VolunteerService.getInstance();
+    const service = await VolunteerService.getInstance(session.accessToken);
     return await service.getApprovedGroupsList();
   } catch (error) {
     console.error("Error fetching approved groups list:", error);
@@ -387,7 +387,7 @@ export async function assignVolunteerToGroup(formData: FormData): Promise<{ succ
       userId = session.userProfile.User_ID;
     }
 
-    const service = await VolunteerService.getInstance();
+    const service = await VolunteerService.getInstance(session.accessToken);
     await service.assignVolunteerToGroup({
       currentGroupParticipantId,
       participantId,

--- a/src/lib/providers/ministry-platform/client.ts
+++ b/src/lib/providers/ministry-platform/client.ts
@@ -4,37 +4,62 @@ import { HttpClient } from "./utils/http-client";
 // Token refresh interval - refresh 5 minutes before actual expiration for safety
 const TOKEN_LIFE = 5 * 60 * 1000; // 5 minutes
 
+export interface MinistryPlatformClientOptions {
+    /** Pre-authenticated user access token (from OIDC session). When provided,
+     *  the client uses this token directly instead of client_credentials flow. */
+    accessToken?: string;
+}
+
 /**
  * MinistryPlatformClient - Core HTTP client with automatic authentication management
- * 
- * Manages OAuth2 client credentials authentication and provides a configured HttpClient
- * instance for all Ministry Platform API operations. Handles token lifecycle including
- * automatic refresh before expiration.
+ *
+ * Manages OAuth2 authentication and provides a configured HttpClient instance for all
+ * Ministry Platform API operations. Supports two authentication modes:
+ *
+ * 1. **Client credentials** (default) — uses MINISTRY_PLATFORM_CLIENT_ID/SECRET to obtain
+ *    a token via the client_credentials grant. All API calls run as the API Client User.
+ *
+ * 2. **User access token** — uses a pre-authenticated token from the user's OIDC session.
+ *    API calls run as the logged-in user, respecting their MP permissions and producing
+ *    accurate audit logs. Token refresh is handled by NextAuth (auth.ts), not this client.
  */
 export class MinistryPlatformClient {
     private token: string = ""; // Current access token
     private expiresAt: Date = new Date(0); // Token expiration time (initialized to epoch to force refresh)
     private baseUrl: string; // Ministry Platform instance base URL
     private httpClient: HttpClient; // HTTP client instance with token injection
+    private isUserToken: boolean = false; // Whether using a user access token (vs. client credentials)
 
     /**
      * Creates a new MinistryPlatformClient instance
-     * Initializes the HTTP client and sets up token management
+     * @param options Optional configuration. Pass `accessToken` to use the user's OIDC token
+     *               instead of client credentials.
      */
-    constructor() {
+    constructor(options?: MinistryPlatformClientOptions) {
         // Get base URL from environment variable
         this.baseUrl = process.env.MINISTRY_PLATFORM_BASE_URL!;
-        
+
+        if (options?.accessToken) {
+            // User token mode: use the pre-authenticated token directly.
+            // Token refresh is managed by NextAuth's JWT callback, not by this client.
+            this.token = options.accessToken;
+            this.expiresAt = new Date(Date.now() + 60 * 60 * 1000); // Trust auth.ts to keep it fresh
+            this.isUserToken = true;
+        }
+
         // Create HTTP client with token getter function for automatic authentication
         this.httpClient = new HttpClient(this.baseUrl, () => this.token);
     }
 
     /**
-     * Ensures the authentication token is valid and refreshes if necessary
-     * This method should be called before making any API requests to guarantee authentication
-     * @throws Error if token refresh fails
+     * Ensures the authentication token is valid and refreshes if necessary.
+     * In user-token mode this is a no-op — NextAuth manages the token lifecycle.
+     * @throws Error if token refresh fails (client credentials mode only)
      */
     public async ensureValidToken(): Promise<void> {
+        // User tokens are managed by auth.ts JWT callback — nothing to do here
+        if (this.isUserToken) return;
+
         console.log("Checking token validity...");
         console.log("Expires at: ", this.expiresAt);
         console.log("Current time: ", new Date());
@@ -42,15 +67,15 @@ export class MinistryPlatformClient {
         // Check if token is expired or about to expire
         if (this.expiresAt < new Date()) {
             console.log("Token expired, refreshing...");
-            
+
             try {
                 // Get new access token using client credentials flow
                 const creds = await getClientCredentialsToken();
                 this.token = creds.access_token;
-                
+
                 // Set expiration time with safety buffer (TOKEN_LIFE before actual expiration)
                 this.expiresAt = new Date(Date.now() + TOKEN_LIFE);
-                
+
                 console.log("Token refreshed. Expires at: ", this.expiresAt);
             } catch (error) {
                 console.error("Failed to refresh token:", error);

--- a/src/lib/providers/ministry-platform/helper.ts
+++ b/src/lib/providers/ministry-platform/helper.ts
@@ -17,27 +17,44 @@ import {
 } from "./types";
 import type { ZodObject, ZodRawShape } from "zod";
 
+export interface MPHelperOptions {
+  /** Pre-authenticated user access token (from OIDC session). When provided,
+   *  all API calls authenticate as the user instead of the API Client User. */
+  accessToken?: string;
+}
+
 /**
  * MPHelper - Main Public API for Ministry Platform Operations
  *
  * Provides a simplified, type-safe interface for all Ministry Platform functionality.
- * Acts as a facade over the ministryPlatformProvider singleton, offering:
+ * Acts as a facade over the MinistryPlatformProvider, offering:
  * - Simplified parameter handling
  * - Type safety with generics
  * - Comprehensive error handling and logging
  * - Consistent API patterns across all operations
  *
+ * Supports two authentication modes:
+ * - `new MPHelper()` — uses client credentials (API Client User). Suitable for
+ *   system-level operations like dashboard caches and type generation.
+ * - `new MPHelper({ accessToken })` — uses the logged-in user's OIDC token.
+ *   API calls respect the user's MP permissions and produce accurate audit logs.
+ *
  * This is the primary entry point for all Ministry Platform operations in the application.
  */
 export class MPHelper {
-  private provider: MinistryPlatformProvider; // Reference to the singleton provider instance
+  private provider: MinistryPlatformProvider;
 
   /**
    * Creates a new MPHelper instance
-   * Gets the singleton provider instance for all operations
+   * @param options Optional configuration. Pass `accessToken` to authenticate as the
+   *               logged-in user instead of the API Client User.
    */
-  constructor() {
-    this.provider = MinistryPlatformProvider.getInstance();
+  constructor(options?: MPHelperOptions) {
+    if (options?.accessToken) {
+      this.provider = MinistryPlatformProvider.withAccessToken(options.accessToken);
+    } else {
+      this.provider = MinistryPlatformProvider.getInstance();
+    }
   }
 
   // =================================================================

--- a/src/lib/providers/ministry-platform/index.ts
+++ b/src/lib/providers/ministry-platform/index.ts
@@ -1,5 +1,6 @@
 export { MinistryPlatformProvider } from './provider';
 export { MPHelper } from './helper';
+export type { MPHelperOptions } from './helper';
 export { MinistryPlatformClient } from './client';
 
 export * from './types';

--- a/src/services/contactLogService.ts
+++ b/src/services/contactLogService.ts
@@ -14,36 +14,26 @@ export class ContactLogService {
   private static instance: ContactLogService;
   private mp: MPHelper | null = null;
 
-  /**
-   * Private constructor to enforce singleton pattern
-   * Initializes the service when instantiated
-   */
-  private constructor() {
-    this.initialize();
-  }
+  private constructor() {}
 
   /**
-   * Gets the singleton instance of ContactLogService
-   * Creates a new instance if one doesn't exist and ensures it's properly initialized
-   * 
-   * @returns Promise<ContactLogService> - The initialized ContactLogService instance
+   * Returns a ContactLogService instance.
+   * @param accessToken Optional user access token from the OIDC session. When provided,
+   *                    creates a per-request instance that authenticates as the logged-in
+   *                    user (respecting their MP permissions and producing accurate audit logs).
+   *                    When omitted, returns the singleton instance using client credentials.
    */
-  public static async getInstance(): Promise<ContactLogService> {
+  public static async getInstance(accessToken?: string): Promise<ContactLogService> {
+    if (accessToken) {
+      const instance = new ContactLogService();
+      instance.mp = new MPHelper({ accessToken });
+      return instance;
+    }
     if (!ContactLogService.instance) {
       ContactLogService.instance = new ContactLogService();
-      await ContactLogService.instance.initialize();
+      ContactLogService.instance.mp = new MPHelper();
     }
     return ContactLogService.instance;
-  }
-
-  /**
-   * Initializes the ContactLogService by creating a new MPHelper instance
-   * This method sets up the Ministry Platform connection helper
-   * 
-   * @returns Promise<void>
-   */
-  private async initialize(): Promise<void> {
-    this.mp = new MPHelper();
   }
 
   /**

--- a/src/services/contactService.ts
+++ b/src/services/contactService.ts
@@ -12,36 +12,26 @@ export class ContactService {
   private static instance: ContactService;
   private mp: MPHelper | null = null;
 
-  /**
-   * Private constructor to enforce singleton pattern
-   * Initializes the service when instantiated
-   */
-  private constructor() {
-    this.initialize();
-  }
+  private constructor() {}
 
   /**
-   * Gets the singleton instance of ContactService
-   * Creates a new instance if one doesn't exist and ensures it's properly initialized
-   * 
-   * @returns Promise<ContactService> - The initialized ContactService instance
+   * Returns a ContactService instance.
+   * @param accessToken Optional user access token from the OIDC session. When provided,
+   *                    creates a per-request instance that authenticates as the logged-in
+   *                    user (respecting their MP permissions and producing accurate audit logs).
+   *                    When omitted, returns the singleton instance using client credentials.
    */
-  public static async getInstance(): Promise<ContactService> {
+  public static async getInstance(accessToken?: string): Promise<ContactService> {
+    if (accessToken) {
+      const instance = new ContactService();
+      instance.mp = new MPHelper({ accessToken });
+      return instance;
+    }
     if (!ContactService.instance) {
       ContactService.instance = new ContactService();
-      await ContactService.instance.initialize();
+      ContactService.instance.mp = new MPHelper();
     }
     return ContactService.instance;
-  }
-
-  /**
-   * Initializes the ContactService by creating a new MPHelper instance
-   * This method sets up the Ministry Platform connection helper
-   * 
-   * @returns Promise<void>
-   */
-  private async initialize(): Promise<void> {
-    this.mp = new MPHelper();
   }
 
   /**

--- a/src/services/toolService.ts
+++ b/src/services/toolService.ts
@@ -12,36 +12,26 @@ export class ToolService {
   private static instance: ToolService;
   private mp: MPHelper | null = null;
 
-  /**
-   * Private constructor to enforce singleton pattern
-   * Initializes the service when instantiated
-   */
-  private constructor() {
-    this.initialize();
-  }
+  private constructor() {}
 
   /**
-   * Gets the singleton instance of ToolService
-   * Creates a new instance if one doesn't exist and ensures it's properly initialized
-   * 
-   * @returns Promise<ToolService> - The initialized ToolService instance
+   * Returns a ToolService instance.
+   * @param accessToken Optional user access token from the OIDC session. When provided,
+   *                    creates a per-request instance that authenticates as the logged-in
+   *                    user (respecting their MP permissions and producing accurate audit logs).
+   *                    When omitted, returns the singleton instance using client credentials.
    */
-  public static async getInstance(): Promise<ToolService> {
+  public static async getInstance(accessToken?: string): Promise<ToolService> {
+    if (accessToken) {
+      const instance = new ToolService();
+      instance.mp = new MPHelper({ accessToken });
+      return instance;
+    }
     if (!ToolService.instance) {
       ToolService.instance = new ToolService();
-      await ToolService.instance.initialize();
+      ToolService.instance.mp = new MPHelper();
     }
     return ToolService.instance;
-  }
-
-  /**
-   * Initializes the ToolService by creating a new MPHelper instance
-   * This method sets up the Ministry Platform connection helper
-   * 
-   * @returns Promise<void>
-   */
-  private async initialize(): Promise<void> {
-    this.mp = new MPHelper();
   }
 
   /**

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -11,36 +11,26 @@ export class UserService {
   private static instance: UserService;
   private mp: MPHelper | null = null;
 
-  /**
-   * Private constructor to enforce singleton pattern
-   * Initializes the service when instantiated
-   */
-  private constructor() {
-    this.initialize();
-  }
+  private constructor() {}
 
   /**
-   * Gets the singleton instance of UserService
-   * Creates a new instance if one doesn't exist and ensures it's properly initialized
-   * 
-   * @returns Promise<UserService> - The initialized UserService instance
+   * Returns a UserService instance.
+   * @param accessToken Optional user access token from the OIDC session. When provided,
+   *                    creates a per-request instance that authenticates as the logged-in
+   *                    user (respecting their MP permissions and producing accurate audit logs).
+   *                    When omitted, returns the singleton instance using client credentials.
    */
-  public static async getInstance(): Promise<UserService> {
+  public static async getInstance(accessToken?: string): Promise<UserService> {
+    if (accessToken) {
+      const instance = new UserService();
+      instance.mp = new MPHelper({ accessToken });
+      return instance;
+    }
     if (!UserService.instance) {
       UserService.instance = new UserService();
-      await UserService.instance.initialize();
+      UserService.instance.mp = new MPHelper();
     }
     return UserService.instance;
-  }
-
-  /**
-   * Initializes the UserService by creating a new MPHelper instance
-   * This method sets up the Ministry Platform connection helper
-   * 
-   * @returns Promise<void>
-   */
-  private async initialize(): Promise<void> {
-    this.mp = new MPHelper();
   }
 
   /**


### PR DESCRIPTION
## Summary
- All server actions previously used the API client user's credentials (`client_credentials` grant), causing audit logs to show "API User" and bypassing per-user data access permissions
- Server actions now pass `session.accessToken` through the service layer to `MPHelper`, so Ministry Platform authenticates requests as the logged-in user
- Dashboard cache and auth callbacks remain on client credentials (appropriate for system-level operations)

## Test plan
- [x] Log in and perform actions (contact lookup, volunteer processing, contact logs) — verify MP audit log shows the logged-in user, not "API User"
- [x] Verify dashboard data loads correctly (still uses client credentials)
- [x] Verify no regressions in contact lookup, volunteer processing, and contact log features
- [x] Confirm session expiry / unauthenticated state is handled gracefully

---
Closes #7

Generated with [Claude Code](https://claude.ai/code)