### PR TITLE
fix: suppress hydration mismatch on dashboard date fields

### DIFF
--- a/src/components/dashboard/dashboard-metrics.tsx
+++ b/src/components/dashboard/dashboard-metrics.tsx
@@ -178,8 +178,8 @@ export function DashboardMetrics({ data, showCompare = true, isSingleMonth = fal
             <div className="space-y-2 text-sm">
               <p><strong>Group Types:</strong> {data.groupTypeMetrics.length} types tracked</p>
               <p><strong>Event Types:</strong> {data.eventTypeMetrics.length} types tracked</p>
-              <p><strong>Period:</strong> {new Date(data.currentPeriod.periodStart).toLocaleDateString()} - {new Date(data.currentPeriod.periodEnd).toLocaleDateString()}</p>
-              <p><strong>Generated:</strong> {new Date(data.generatedAt).toLocaleString()}</p>
+              <p suppressHydrationWarning><strong>Period:</strong> {new Date(data.currentPeriod.periodStart).toLocaleDateString()} - {new Date(data.currentPeriod.periodEnd).toLocaleDateString()}</p>
+              <p suppressHydrationWarning><strong>Generated:</strong> {new Date(data.generatedAt).toLocaleString()}</p>
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- `DashboardMetrics` renders two date fields using `toLocaleDateString()` / `toLocaleString()` with no explicit timezone, causing the server (UTC) and client (local timezone) to produce different strings
- Added `suppressHydrationWarning` to the two `<p>` elements containing these dates — the React-recommended approach for intentional server/client locale differences
- No behavior change; the client value (user's local timezone) is always what's displayed after hydration

## Test plan
- [x] Open the dashboard — confirm the Turbopack hydration error is gone
- [x] Verify the "Period" and "Generated" fields still display correct dates in local timezone

Generated with [Claude Code](https://claude.ai/code)