### PR TITLE
feat: migrate unstable_cache to Cache Components with PPR

### DIFF
--- a/.claude/draft-issue-dashboard-redesign.md
+++ b/.claude/draft-issue-dashboard-redesign.md
@@ -202,12 +202,26 @@ Participant_Milestones
   → Milestone_ID → Milestones
 ```
 
+### Caching architecture (updated 2026-02-23)
+The project now uses Cache Components (`cacheComponents: true` in `next.config.ts`) with PPR. New cached data functions should use the `'use cache'` directive with `cacheLife()` and `cacheTag()` instead of `unstable_cache`. Example:
+```ts
+async function getCachedEngagementData(startDateIso: string, endDateIso: string) {
+  'use cache';
+  cacheLife({ revalidate: 21600 }); // 6 hours
+  cacheTag('dashboard-data', 'engagement');
+  // ... fetch data ...
+}
+```
+Important: `new Date()` and other non-deterministic expressions must stay OUTSIDE `'use cache'` functions. Pass dates as serializable parameters (e.g., ISO strings).
+
+The dashboard page uses PPR — the outer shell pre-renders as static HTML, and `DashboardContent` (wrapped in `<Suspense>`) streams at request time via `await connection()`.
+
 ### Files that will be modified
 - `src/components/dashboard/dashboard-metrics.tsx` — major refactor for section layout
 - `src/components/dashboard/dashboard-shell.tsx` — may need section collapse state
-- `src/services/dashboardService.ts` — new data methods
+- `src/services/dashboardService.ts` — new data methods (use `'use cache'` pattern)
 - `src/lib/dto/dashboard.ts` — new interfaces for new data types
-- `src/components/dashboard/actions.ts` — new server actions for new data
+- `src/components/dashboard/actions.ts` — new cached server actions (use `'use cache'` + `cacheLife` + `cacheTag`)
 
 ### New files expected
 - `src/components/dashboard/venn-diagram.tsx` — engagement Venn

--- a/.claude/ideas.md
+++ b/.claude/ideas.md
@@ -28,7 +28,7 @@ Ideas and enhancements for the MPNext project. This file syncs bidirectionally w
 - ~~[Dashboard Date Range Selector (#20)](#dashboard-date-range-selector-20)~~ ✅
 
 ### Technical Debt ([#46](https://github.com/The-Moody-Church/mp-charts/issues/46))
-- [Migrate `unstable_cache` to Cache Components (#21)](#migrate-unstable_cache-to-cache-components-use-cache--reverted-2026-02-14-21)
+- [~~Migrate `unstable_cache` to Cache Components (#21)~~](#migrate-unstable_cache-to-cache-components-use-cache--completed-2026-02-23-21)
 - [Review upstream PR #42 (#35)](#review-upstream-pr42-35)
 - ~~[Upgrade to Next.js 16](#upgrade-to-nextjs-16)~~ ✅
 - ~~[Refine MP Permissions (#7)](#refine-mp-permissions-7)~~ ✅
@@ -120,14 +120,8 @@ Replace the hardcoded ministry year date ranges with an interactive date selecto
 
 ## Technical Debt
 
-### Migrate `unstable_cache` to Cache Components (`use cache`) ⚠️ READY TO MIGRATE ([#21](https://github.com/The-Moody-Church/mp-charts/issues/21))
-Previously reverted ([PR #10](https://github.com/The-Moody-Church/mp-charts/pull/10)) because `'use cache'` was only in canary builds. **Now available in stable Next.js 16.** Investigation (2026-02-23) confirmed two migration paths:
-
-**Option A (Recommended): `experimental: { useCache: true }`** — Drop-in replacement for 4 `unstable_cache` call sites. No PPR, no Suspense boundaries required. Minimal diff.
-
-**Option B: `cacheComponents: true`** — Full Cache Components with PPR. Stable/non-experimental but requires `<Suspense>` boundaries around all uncached dynamic data. More invasive.
-
-4 call sites to migrate: `getCachedDashboardData` (6h), `getCachedFullRangeData` (6h), `getCachedGroupTypes` (24h), `getCachedEventTypes` (24h). All in `actions.ts` and `dashboardService.ts`. Compatible with `output: "standalone"` and Docker.
+### ~~Migrate `unstable_cache` to Cache Components (`use cache`)~~ ✅ COMPLETED (2026-02-23) ([#21](https://github.com/The-Moody-Church/mp-charts/issues/21))
+Migrated from `unstable_cache` to `'use cache'` directive with `cacheComponents: true` (full PPR). All 4 call sites converted to `'use cache'` + `cacheLife()` + `cacheTag()`. Added Suspense boundaries to all pages with dynamic data. Dashboard uses `connection()` to defer to runtime. Build output shows `◐ (Partial Prerender)` for all authenticated pages.
 
 ### review upstream pr42 ([#35](https://github.com/The-Moody-Church/mp-charts/issues/35))
 Review upstream pr 42 for updates and cherry pick changes or merge all features.

--- a/.claude/plan-baptism-processing.md
+++ b/.claude/plan-baptism-processing.md
@@ -122,8 +122,9 @@ Same `"use server"` + `requireSession()` + delegate pattern as volunteer `action
 ### Components
 
 **Page** (`src/app/(web)/baptism-processing/page.tsx`):
-- Server Component, same as volunteer page
+- Sync wrapper with Suspense + async inner component (PPR pattern, same as volunteer page)
 - Deep link param: `?applicant=123`
+- Pattern: page exports sync function → `<Suspense>` → async `PageContent` awaits `searchParams`
 
 **Main** (`baptism-processing.tsx`):
 - `"use client"` with two tabs: "Current Baptism Applicants" / "Paused Baptism Applicants"

--- a/.claude/session-summary-2026-02-23.md
+++ b/.claude/session-summary-2026-02-23.md
@@ -1,58 +1,113 @@
 # Session Summary — 2026-02-23
 
-## Investigation: `unstable_cache` → `use cache` Migration (Issue #21)
+## Cache Components Migration: `unstable_cache` → `'use cache'` + PPR (Issue #21)
 
 ### Task
-Investigated whether the `unstable_cache` → `'use cache'` migration is now feasible in Next.js 16 stable, following the revert in PR #10.
+Investigated feasibility, then implemented full migration from `unstable_cache` to `'use cache'` with `cacheComponents: true` (PPR) in Next.js 16 stable.
 
-### Findings
+### Implementation Summary
 
-**Migration is now possible.** Next.js 16 (stable since Oct 2025) ships `'use cache'` as a production-ready feature. The original revert was because `'use cache'` was canary-only at the time.
+Chose **Option B** (`cacheComponents: true`) — the full Cache Components upgrade with Partial Prerendering. All authenticated pages now show `◐ (Partial Prerender)` in build output — static HTML shells load instantly, dynamic content streams via Suspense.
 
-### Current `unstable_cache` Usage (4 call sites)
+### Changes Made
 
-| File | Function | TTL | Tags |
-|---|---|---|---|
-| `src/components/dashboard/actions.ts:10` | `getCachedDashboardData()` | 6h (21600s) | `dashboard-data`, `year-${year}` |
-| `src/components/dashboard/actions.ts:28` | `getCachedFullRangeData()` | 6h (21600s) | `dashboard-data`, `dashboard-full-range` |
-| `src/services/dashboardService.ts:23` | `getCachedGroupTypes()` | 24h (86400s) | `group-types` |
-| `src/services/dashboardService.ts:43` | `getCachedEventTypes()` | 24h (86400s) | `event-types` |
+#### 1. Enable Cache Components
+- **`next.config.ts`** — Added `cacheComponents: true`
 
-Also: `src/services/volunteerService.ts:122` has an in-memory `Map` cache (unrelated to `unstable_cache`).
+#### 2. Migrate 4 `unstable_cache` call sites to `'use cache'`
 
-### Two Migration Paths Identified
+**`src/components/dashboard/actions.ts`**:
+- `getCachedDashboardData(ministryYear)` → `'use cache'` + `cacheLife({ revalidate: 21600 })` + `cacheTag('dashboard-data', 'year-N')`
+- `getCachedFullRangeData(earliestYear, endDateIso)` → same pattern; moved `new Date()` OUT of cache boundary into caller `getFullRangeDashboardMetrics()`, passing end date as ISO string parameter
+- Removed `unstable_cache` import, added `cacheLife, cacheTag` imports
+- `refreshDashboardCache()` — kept `revalidateTag()` with `{ expire: 0 }` (compatible)
 
-#### Option A: `experimental: { useCache: true }` (Recommended)
-- Enables `'use cache'` directive without PPR or Suspense requirements
-- Drop-in replacement for the 4 `unstable_cache` call sites
-- Minimal diff — each call becomes `'use cache'` + `cacheLife()` + `cacheTag()`
-- Still under `experimental` flag, but the directive itself is stable in Next.js 16
+**`src/services/dashboardService.ts`**:
+- `getCachedGroupTypes(ids)` → `'use cache'` + `cacheLife({ revalidate: 86400 })` + `cacheTag('group-types')`
+- `getCachedEventTypes(ids)` → same pattern
+- Removed double-invoke pattern (`getCachedGroupTypes(ids)()` → `getCachedGroupTypes(ids)`)
+- Updated JSDoc references from "unstable_cache" to "'use cache'"
 
-#### Option B: `cacheComponents: true` (Full Cache Components)
-- Stable, non-experimental — recommended by Next.js team
-- Enables PPR (Partial Prerendering) automatically
-- Requires `<Suspense>` boundaries around ALL uncached dynamic data access
-- More invasive — build errors until all components are properly wrapped
-- Better long-term path (access to `'use cache: remote'`, PPR performance)
+#### 3. Add Suspense boundaries for PPR
 
-### Compatibility Confirmed
-- `output: "standalone"` — works with both options
-- Docker self-hosting — in-memory cache works for single-container deployment
-- `revalidateTag()` — compatible with `'use cache'` tags
-- Existing `{ expire: 0 }` pattern in `refreshDashboardCache()` is compatible
+**`src/app/(web)/layout.tsx`**:
+- Wrapped `<AuthWrapper>` in `<Suspense>` (uses `headers()` — per-request dynamic data)
+- Removed unnecessary `async` keyword (layout has no await)
 
-### Recommendation
-Start with Option A for immediate migration (focused, low-risk). Upgrade to Option B when ready for a larger architectural change (e.g., dashboard redesign #42).
+**`src/app/(web)/dashboard/page.tsx`**:
+- Split into sync `DashboardPage` wrapper + async `DashboardContent` inner component
+- `DashboardContent` wrapped in `<Suspense>`, uses `await connection()` to skip build-time prerender (API not available during build)
+- Updated BUILD_ID to `cache-components-v1`
+
+**`src/app/(web)/volunteer-processing/page.tsx`**:
+- Split into sync `VolunteerProcessingPage` + async `VolunteerProcessingContent`
+- Wrapped in `<Suspense>` (uses `searchParams` — dynamic API)
+
+**`src/app/(web)/contactlookup/[guid]/page.tsx`**:
+- Split into sync `ContactLookupDetailPage` + async `ContactLookupDetailContent`
+- Wrapped in `<Suspense>` (uses dynamic `params`)
+
+**`src/app/(web)/tools/template/page.tsx`**:
+- Split into sync `TemplateToolPage` + async `TemplateToolContent`
+- Wrapped in `<Suspense>` (uses `searchParams` + async service call)
+
+**`src/app/layout.tsx`**:
+- Removed unnecessary `async` keyword
+
+#### 4. Documentation Updates
+
+**`CLAUDE.md`**:
+- Updated Architecture line to include "Cache Components/PPR"
+- Added comprehensive "Caching & PPR" section with `'use cache'` patterns, Suspense/PPR patterns, and layout auth pattern
+
+**`.claude/ideas.md`**:
+- Marked issue #21 as `✅ COMPLETED (2026-02-23)`
+
+**`.claude/plan-baptism-processing.md`**:
+- Updated page pattern note to reference PPR/Suspense pattern
+
+**`.claude/draft-issue-dashboard-redesign.md`**:
+- Added caching architecture section documenting `'use cache'` pattern for new charts
+
+### Build Output
+
+```
+Route (app)
+┌ ◐ /
+├ ○ /_not-found
+├ ƒ /api/auth/[...all]
+├ ◐ /contactlookup
+├ ◐ /contactlookup/[guid]
+├ ◐ /dashboard
+├ ◐ /home
+├ ○ /signin
+├ ◐ /tools/template
+└ ◐ /volunteer-processing
+
+○  (Static)             prerendered as static content
+◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
+ƒ  (Dynamic)            server-rendered on demand
+```
+
+### Key Lessons Learned
+1. `'use cache'` functions must not contain `new Date()` or other non-deterministic expressions — pass as parameters
+2. `'use cache'` functions execute at build time to warm the cache — use `connection()` in the calling component to defer to runtime when the API isn't available during build
+3. `cacheComponents: true` automatically enables PPR — every page with uncached dynamic data needs Suspense boundaries
+4. `searchParams`, `params`, `headers()`, `cookies()` are dynamic APIs that need Suspense with PPR
+5. The double-invoke pattern (`unstable_cache(fn, key, opts)()`) simplifies to direct function call with `'use cache'`
 
 ### Files Modified
-- `.claude/ideas.md` — Updated issue #21 entry from "REVERTED" to "READY TO MIGRATE" with findings
-- `.claude/session-summary-2026-02-23.md` — This file (created)
-
-### Sources
-- [Next.js 16 release blog](https://nextjs.org/blog/next-16)
-- [Next.js `use cache` directive docs](https://nextjs.org/docs/app/api-reference/directives/use-cache)
-- [Next.js `cacheComponents` config](https://nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents)
-- [Next.js `useCache` experimental config](https://nextjs.org/docs/app/api-reference/config/next-config-js/useCache)
-- [Next.js `cacheLife` function](https://nextjs.org/docs/app/api-reference/functions/cacheLife)
-- [Next.js `cacheTag` function](https://nextjs.org/docs/app/api-reference/functions/cacheTag)
-- [Next.js `unstable_cache` (deprecated)](https://nextjs.org/docs/app/api-reference/functions/unstable_cache)
+- `next.config.ts` — added `cacheComponents: true`
+- `src/components/dashboard/actions.ts` — migrated 2 `unstable_cache` → `'use cache'`
+- `src/services/dashboardService.ts` — migrated 2 `unstable_cache` → `'use cache'`
+- `src/app/(web)/layout.tsx` — added Suspense around AuthWrapper
+- `src/app/(web)/dashboard/page.tsx` — PPR pattern with `connection()`
+- `src/app/(web)/volunteer-processing/page.tsx` — PPR Suspense pattern
+- `src/app/(web)/contactlookup/[guid]/page.tsx` — PPR Suspense pattern
+- `src/app/(web)/tools/template/page.tsx` — PPR Suspense pattern
+- `src/app/layout.tsx` — removed unnecessary `async`
+- `CLAUDE.md` — added Caching & PPR section
+- `.claude/ideas.md` — marked #21 completed
+- `.claude/plan-baptism-processing.md` — updated page pattern note
+- `.claude/draft-issue-dashboard-redesign.md` — added caching architecture section
+- `.claude/session-summary-2026-02-23.md` — this file

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ Both files are committed to the repo and must NOT be added to `.gitignore`.
 
 ## Architecture
 
-- **Framework**: Next.js 16 (App Router, Turbopack) with React 19, TypeScript strict mode
+- **Framework**: Next.js 16 (App Router, Turbopack, Cache Components/PPR) with React 19, TypeScript strict mode
 - **Ministry Platform Integration**: Custom provider at `src/lib/providers/ministry-platform/` with REST API client, auth, and type-safe models
 - **Auth**: Better Auth (`better-auth@^1.4`) with Ministry Platform OAuth via `genericOAuth` plugin (`src/lib/auth.ts`)
   - **Server Config**: `src/lib/auth.ts` — `betterAuth()` with `genericOAuth`, `customSession`, `nextCookies()` plugins
@@ -112,6 +112,84 @@ Both files are committed to the repo and must NOT be added to `.gitignore`.
 - **ESLint**: Uses `eslint .` directly (not `next lint`); config is native flat config in `eslint.config.mjs`
 - **Async Dynamic APIs**: `params`, `searchParams`, `cookies()`, `headers()` must always be awaited — synchronous access is removed
 - **Dev output**: `next dev` outputs to `.next/dev` (not `.next`)
+- **Cache Components (PPR)**: `cacheComponents: true` in `next.config.ts` enables Partial Prerendering — static shells pre-render at build time, dynamic content streams at request time
+
+## Caching & PPR
+
+The project uses **Cache Components** (`cacheComponents: true`) with **Partial Prerendering (PPR)**. All authenticated pages render as `◐ (Partial Prerender)` — the static HTML shell loads instantly, then dynamic content streams in via Suspense boundaries.
+
+### `'use cache'` Directive
+
+Data-fetching functions use the `'use cache'` directive with `cacheLife()` and `cacheTag()` from `next/cache`:
+
+```typescript
+import { cacheLife, cacheTag } from 'next/cache';
+
+async function getCachedData(key: string) {
+  'use cache';
+  cacheLife({ revalidate: 21600 }); // 6 hours
+  cacheTag('my-tag');
+  // ... fetch data ...
+}
+```
+
+**Rules for `'use cache'` functions:**
+- `new Date()` and other non-deterministic expressions must stay OUTSIDE the function — pass as serializable parameters
+- Function arguments automatically become the cache key
+- Invalidate with `revalidateTag('my-tag', { expire: 0 })` from server actions
+
+**Current cached functions:**
+| Function | TTL | Tags | File |
+|---|---|---|---|
+| `getCachedDashboardData(year)` | 6h | `dashboard-data`, `year-N` | `src/components/dashboard/actions.ts` |
+| `getCachedFullRangeData(year, endDate)` | 6h | `dashboard-data`, `dashboard-full-range` | `src/components/dashboard/actions.ts` |
+| `getCachedGroupTypes(ids)` | 24h | `group-types` | `src/services/dashboardService.ts` |
+| `getCachedEventTypes(ids)` | 24h | `event-types` | `src/services/dashboardService.ts` |
+
+### Suspense & PPR Pattern for Pages
+
+Pages with dynamic data access (`params`, `searchParams`, `headers()`) must use the Suspense pattern:
+
+```typescript
+// Sync wrapper — pre-renders as static HTML shell
+export default function MyPage({ searchParams }: Props) {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <MyPageContent searchParams={searchParams} />
+    </Suspense>
+  );
+}
+
+// Async inner component — streams at request time
+async function MyPageContent({ searchParams }: Props) {
+  const params = await searchParams;
+  return <ClientComponent data={params} />;
+}
+```
+
+For pages that call `'use cache'` functions but depend on runtime APIs (e.g., dashboard), use `connection()` from `next/server` to skip build-time prerendering:
+
+```typescript
+import { connection } from 'next/server';
+
+async function DashboardContent() {
+  await connection(); // Defer to runtime — API not available at build time
+  const data = await getCachedData();
+  return <Dashboard data={data} />;
+}
+```
+
+### Layout Auth Pattern
+
+The web layout wraps `AuthWrapper` (which uses `headers()`) in a Suspense boundary so the outer HTML shell pre-renders:
+
+```typescript
+<Suspense fallback={<Loading />}>
+  <AuthWrapper>
+    <Providers>{children}</Providers>
+  </AuthWrapper>
+</Suspense>
+```
 
 ## Code Style
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone", // Required for Docker deployment
+  cacheComponents: true, // Enables Cache Components (PPR + 'use cache' directive)
 };
 
 export default nextConfig;

--- a/src/app/(web)/contactlookup/[guid]/page.tsx
+++ b/src/app/(web)/contactlookup/[guid]/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { ContactLookupDetails } from "@/components/contact-lookup-details";
 
 interface ContactLookupDetailPageProps {
@@ -6,7 +7,21 @@ interface ContactLookupDetailPageProps {
   }>;
 }
 
-export default async function ContactLookupDetailPage({
+export default function ContactLookupDetailPage({
+  params,
+}: ContactLookupDetailPageProps) {
+  return (
+    <Suspense fallback={
+      <div className="container mx-auto p-4 space-y-6">
+        <div className="text-muted-foreground">Loading contact...</div>
+      </div>
+    }>
+      <ContactLookupDetailContent params={params} />
+    </Suspense>
+  );
+}
+
+async function ContactLookupDetailContent({
   params,
 }: ContactLookupDetailPageProps) {
   const { guid } = await params;

--- a/src/app/(web)/dashboard/page.tsx
+++ b/src/app/(web)/dashboard/page.tsx
@@ -1,21 +1,32 @@
+import { Suspense } from 'react';
+import { connection } from 'next/server';
 import { getFullRangeDashboardMetrics } from '@/components/dashboard/actions';
 import { DashboardShell } from '@/components/dashboard/dashboard-shell';
 
-const BUILD_ID = 'client-side-filter-v1';
+const BUILD_ID = 'cache-components-v1';
 
-export default async function DashboardPage() {
-
-  // Fetch full date range on server; client-side filtering handles date selection
-  const dashboardData = await getFullRangeDashboardMetrics();
-
+export default function DashboardPage() {
   return (
     <div className="container mx-auto p-8">
       {process.env.NODE_ENV === 'development' && (
         <div className="mb-4 rounded-md border border-blue-300 bg-blue-50 px-4 py-2 text-xs text-blue-800 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-200">
-          <strong>Build:</strong> {BUILD_ID} | <strong>Branch:</strong> claude/review-date-filter-UfQYm | <strong>Rendered:</strong> {new Date().toISOString()}
+          <strong>Build:</strong> {BUILD_ID} | <strong>Rendered:</strong> {new Date().toISOString()}
         </div>
       )}
-      <DashboardShell initialData={dashboardData} />
+      <Suspense fallback={
+        <div className="text-muted-foreground">Loading dashboard...</div>
+      }>
+        <DashboardContent />
+      </Suspense>
     </div>
   );
+}
+
+async function DashboardContent() {
+  // Signal that this component depends on the incoming request — skip build-time
+  // prerender (API credentials aren't available during build). With PPR, the outer
+  // page shell renders as static HTML and this streams in at request time.
+  await connection();
+  const dashboardData = await getFullRangeDashboardMetrics();
+  return <DashboardShell initialData={dashboardData} />;
 }

--- a/src/app/(web)/layout.tsx
+++ b/src/app/(web)/layout.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import type { Metadata, Viewport } from "next";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
@@ -17,7 +18,7 @@ export const viewport: Viewport = {
   themeColor: "#000000",
 }
 
-export default async function WebLayout({
+export default function WebLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
@@ -30,18 +31,24 @@ export default async function WebLayout({
   };
 
   return (
-    <AuthWrapper>
-      <Providers runtimeConfig={runtimeConfig}>
-        <div className={`flex flex-col ${GeistSans.variable} ${GeistMono.variable}`}>
-          <Header />
-          <main className="flex-1 mt-16">
-            <div className="px-4 py-3 border-b bg-muted/30">
-              <DynamicBreadcrumb />
-            </div>
-            {children}
-          </main>
-        </div>
-      </Providers>
-    </AuthWrapper>
+    <Suspense fallback={
+      <div className="flex h-screen items-center justify-center">
+        <div className="text-muted-foreground">Loading...</div>
+      </div>
+    }>
+      <AuthWrapper>
+        <Providers runtimeConfig={runtimeConfig}>
+          <div className={`flex flex-col ${GeistSans.variable} ${GeistMono.variable}`}>
+            <Header />
+            <main className="flex-1 mt-16">
+              <div className="px-4 py-3 border-b bg-muted/30">
+                <DynamicBreadcrumb />
+              </div>
+              {children}
+            </main>
+          </div>
+        </Providers>
+      </AuthWrapper>
+    </Suspense>
   );
 }

--- a/src/app/(web)/tools/template/page.tsx
+++ b/src/app/(web)/tools/template/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { TemplateTool } from "./template-tool";
 import { parseToolParams } from "@/lib/tool-params";
 
@@ -5,8 +6,20 @@ interface TemplatePageProps {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }
 
-export default async function TemplateToolPage({ searchParams }: TemplatePageProps) {
+export default function TemplateToolPage({ searchParams }: TemplatePageProps) {
+  return (
+    <Suspense fallback={
+      <div className="container mx-auto p-8">
+        <div className="text-muted-foreground">Loading tool...</div>
+      </div>
+    }>
+      <TemplateToolContent searchParams={searchParams} />
+    </Suspense>
+  );
+}
+
+async function TemplateToolContent({ searchParams }: TemplatePageProps) {
   const params = await parseToolParams(await searchParams);
-  
+
   return <TemplateTool params={params} />;
 }

--- a/src/app/(web)/volunteer-processing/page.tsx
+++ b/src/app/(web)/volunteer-processing/page.tsx
@@ -1,10 +1,23 @@
+import { Suspense } from 'react';
 import { VolunteerProcessing } from '@/components/volunteer-processing';
 
 interface VolunteerProcessingPageProps {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }
 
-export default async function VolunteerProcessingPage({ searchParams }: VolunteerProcessingPageProps) {
+export default function VolunteerProcessingPage({ searchParams }: VolunteerProcessingPageProps) {
+  return (
+    <Suspense fallback={
+      <div className="container mx-auto p-8">
+        <div className="text-muted-foreground">Loading volunteers...</div>
+      </div>
+    }>
+      <VolunteerProcessingContent searchParams={searchParams} />
+    </Suspense>
+  );
+}
+
+async function VolunteerProcessingContent({ searchParams }: VolunteerProcessingPageProps) {
   const params = await searchParams;
   const volunteerParam = typeof params.volunteer === 'string' ? Number(params.volunteer) : null;
   const initialVolunteerId = volunteerParam && !isNaN(volunteerParam) ? volunteerParam : null;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import "./globals.css";
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;

--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -1,44 +1,43 @@
 'use server';
 
-import { unstable_cache, revalidatePath, revalidateTag } from 'next/cache';
+import { cacheLife, cacheTag, revalidatePath, revalidateTag } from 'next/cache';
 import { DashboardService } from '@/services/dashboardService';
 import { DashboardData } from '@/lib/dto';
 
 /**
  * Cached dashboard data for a single ministry year (6-hour cache)
  */
-const getCachedDashboardData = (ministryYear: number) =>
-  unstable_cache(
-    async (): Promise<DashboardData> => {
-      // Ministry year runs Sept 1 - Aug 31
-      const startDate = new Date(ministryYear, 8, 1); // September 1
-      const endDate = new Date(ministryYear + 1, 7, 31); // August 31 of next calendar year
+async function getCachedDashboardData(ministryYear: number): Promise<DashboardData> {
+  'use cache';
+  cacheLife({ revalidate: 21600 });
+  cacheTag('dashboard-data', `year-${ministryYear}`);
 
-      const dashboardService = await DashboardService.getInstance();
-      return dashboardService.getDashboardData(startDate, endDate);
-    },
-    [`dashboard-data-${ministryYear}`],
-    { revalidate: 21600, tags: ['dashboard-data', `year-${ministryYear}`] }
-  );
+  // Ministry year runs Sept 1 - Aug 31
+  const startDate = new Date(ministryYear, 8, 1); // September 1
+  const endDate = new Date(ministryYear + 1, 7, 31); // August 31 of next calendar year
+
+  const dashboardService = await DashboardService.getInstance();
+  return dashboardService.getDashboardData(startDate, endDate);
+}
 
 /**
- * Cached full-range dashboard data for 5 ministry years (6-hour cache)
+ * Cached full-range dashboard data for 5 ministry years (6-hour cache).
+ * The endDateIso parameter (YYYY-MM-DD) is computed by the caller so that
+ * `new Date()` stays outside the cache boundary. The date string becomes part
+ * of the automatic cache key, meaning the cache refreshes daily.
  */
-const getCachedFullRangeData = (earliestYear: number, currentYear: number) =>
-  unstable_cache(
-    async (): Promise<DashboardData> => {
-      const startDate = new Date(earliestYear, 8, 1); // September 1, 5 years ago
-      const today = new Date();
-      // Use today or Aug 31 of current+1, whichever is earlier
-      const maxEnd = new Date(currentYear + 1, 7, 31);
-      const endDate = today < maxEnd ? today : maxEnd;
+async function getCachedFullRangeData(earliestYear: number, endDateIso: string): Promise<DashboardData> {
+  'use cache';
+  cacheLife({ revalidate: 21600 });
+  cacheTag('dashboard-data', 'dashboard-full-range');
 
-      const dashboardService = await DashboardService.getInstance();
-      return dashboardService.getDashboardData(startDate, endDate);
-    },
-    [`dashboard-full-range-${earliestYear}-${currentYear}`],
-    { revalidate: 21600, tags: ['dashboard-data', 'dashboard-full-range'] }
-  );
+  const startDate = new Date(earliestYear, 8, 1); // September 1, 5 years ago
+  const [year, month, day] = endDateIso.split('-').map(Number);
+  const endDate = new Date(year, month - 1, day);
+
+  const dashboardService = await DashboardService.getInstance();
+  return dashboardService.getDashboardData(startDate, endDate);
+}
 
 /**
  * Fetches dashboard data for the specified ministry year
@@ -52,7 +51,7 @@ export async function getDashboardMetrics(
   year?: number
 ): Promise<DashboardData> {
   const currentYear = year || getCurrentMinistryYear();
-  return getCachedDashboardData(currentYear)();
+  return getCachedDashboardData(currentYear);
 }
 
 /**
@@ -65,7 +64,14 @@ export async function getDashboardMetrics(
 export async function getFullRangeDashboardMetrics(): Promise<DashboardData> {
   const currentYear = getCurrentMinistryYear();
   const earliestYear = currentYear - 4;
-  return getCachedFullRangeData(earliestYear, currentYear)();
+
+  // Compute end date outside the cache boundary (new Date() is dynamic data)
+  const today = new Date();
+  const maxEnd = new Date(currentYear + 1, 7, 31);
+  const endDate = today < maxEnd ? today : maxEnd;
+  const endDateIso = endDate.toISOString().split('T')[0]; // "YYYY-MM-DD"
+
+  return getCachedFullRangeData(earliestYear, endDateIso);
 }
 
 /**

--- a/src/services/dashboardService.ts
+++ b/src/services/dashboardService.ts
@@ -1,4 +1,4 @@
-import { unstable_cache } from 'next/cache';
+import { cacheLife, cacheTag } from 'next/cache';
 import { MPHelper } from '@/lib/providers/ministry-platform';
 import {
   DashboardData,
@@ -18,44 +18,44 @@ const MONTH_NAMES = [
 ];
 
 /**
- * Cached Group_Types lookup (24-hour cache)
+ * Cached Group_Types lookup (24-hour cache via 'use cache')
+ * The `ids` parameter is automatically part of the cache key.
  */
-const getCachedGroupTypes = (ids: string) =>
-  unstable_cache(
-    async () => {
-      const mp = new MPHelper();
-      return mp.getTableRecords<{
-        Group_Type_ID: number;
-        Group_Type: string;
-      }>({
-        table: 'Group_Types',
-        select: 'Group_Type_ID,Group_Type',
-        filter: `Group_Type_ID IN (${ids})`
-      });
-    },
-    [`group-types-${ids}`],
-    { revalidate: 86400, tags: ['group-types'] }
-  );
+async function getCachedGroupTypes(ids: string) {
+  'use cache';
+  cacheLife({ revalidate: 86400 });
+  cacheTag('group-types');
+
+  const mp = new MPHelper();
+  return mp.getTableRecords<{
+    Group_Type_ID: number;
+    Group_Type: string;
+  }>({
+    table: 'Group_Types',
+    select: 'Group_Type_ID,Group_Type',
+    filter: `Group_Type_ID IN (${ids})`
+  });
+}
 
 /**
- * Cached Event_Types lookup (24-hour cache)
+ * Cached Event_Types lookup (24-hour cache via 'use cache')
+ * The `ids` parameter is automatically part of the cache key.
  */
-const getCachedEventTypes = (ids: string) =>
-  unstable_cache(
-    async () => {
-      const mp = new MPHelper();
-      return mp.getTableRecords<{
-        Event_Type_ID: number;
-        Event_Type: string;
-      }>({
-        table: 'Event_Types',
-        select: 'Event_Type_ID,Event_Type',
-        filter: `Event_Type_ID IN (${ids})`
-      });
-    },
-    [`event-types-${ids}`],
-    { revalidate: 86400, tags: ['event-types'] }
-  );
+async function getCachedEventTypes(ids: string) {
+  'use cache';
+  cacheLife({ revalidate: 86400 });
+  cacheTag('event-types');
+
+  const mp = new MPHelper();
+  return mp.getTableRecords<{
+    Event_Type_ID: number;
+    Event_Type: string;
+  }>({
+    table: 'Event_Types',
+    select: 'Event_Type_ID,Event_Type',
+    filter: `Event_Type_ID IN (${ids})`
+  });
+}
 
 /**
  * DashboardService - Singleton service for managing dashboard metrics
@@ -77,7 +77,7 @@ export class DashboardService {
    *                    user (respecting their MP permissions and producing accurate audit logs).
    *                    When omitted, returns the singleton instance using client credentials.
    *
-   * Note: Cached lookups (Group_Types, Event_Types via unstable_cache) always use client
+   * Note: Cached lookups (Group_Types, Event_Types via 'use cache') always use client
    * credentials since they run outside user request context. The main data queries
    * use the access token when provided.
    */
@@ -95,19 +95,19 @@ export class DashboardService {
   }
 
   /**
-   * Gets Group_Types with 24-hour cache via unstable_cache
+   * Gets Group_Types with 24-hour cache via 'use cache'
    */
   private async getGroupTypesWithCache(groupTypeIds: Set<number>) {
     const ids = Array.from(groupTypeIds).sort().join(',');
-    return getCachedGroupTypes(ids)();
+    return getCachedGroupTypes(ids);
   }
 
   /**
-   * Gets Event_Types with 24-hour cache via unstable_cache
+   * Gets Event_Types with 24-hour cache via 'use cache'
    */
   private async getEventTypesWithCache(eventTypeIds: Set<number>) {
     const ids = Array.from(eventTypeIds).sort().join(',');
-    return getCachedEventTypes(ids)();
+    return getCachedEventTypes(ids);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Enables `cacheComponents: true` in `next.config.ts`, activating **Partial Prerendering (PPR)** across the app — static HTML shells load instantly, dynamic content streams via Suspense
- Migrates all 4 `unstable_cache` call sites to the stable `'use cache'` directive with `cacheLife()` and `cacheTag()` (closes #21)
- Adds `<Suspense>` boundaries to every page with dynamic data access following the PPR pattern: sync wrapper → Suspense → async inner component
- Dashboard uses `connection()` to defer API calls from build time
- Updates CLAUDE.md with new Caching & PPR documentation section

## Test plan

- [x] `npm run build` passes — all authenticated pages show ◐ (Partial Prerender)
- [x] `npm run dev` — verify dashboard loads data correctly
- [x] Verify manual refresh button still invalidates all caches
- [x] Verify all other pages still render correctly
- [x] Docker build + production deployment