### PR TITLE
chore: incorporate upstream PR #52 — replace stale NextAuth refs with Better Auth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,9 +95,9 @@ git log main..upstream/main --oneline
 
 Or review PRs at: https://github.com/MinistryPlatform-Community/MPNext/pulls
 
-#### Last Review: 2026-02-26
+#### Last Review: 2026-02-28
 
-Reviewed all open/merged upstream PRs through PR #51 (release v2026.02.26.1827). Status:
+Reviewed all open/merged upstream PRs through PR #52 (release v2026.02.28.1353). Status:
 
 | PR | Title | Action | Notes |
 |----|-------|--------|-------|
@@ -113,6 +113,7 @@ Reviewed all open/merged upstream PRs through PR #51 (release v2026.02.26.1827).
 | #49 | Restore CODECOV_TOKEN | Skipped | Only relevant with #47 |
 | #50 | Load user roles/groups into MPUserProfile | Incorporated | Added `roles`/`userGroups` to MPUserProfile, parallel fetch from `dp_User_Roles`/`dp_User_User_Groups`; kept our `sanitizeGuid()` + `sanitizeIds()` security (upstream doesn't sanitize); kept `requireSession()` in shared action |
 | #51 | Update deps + fix security vulns | Incorporated | `npm audit fix` resolved 3 CVEs: rollup CVE-2026-27606 (High), minimatch GHSA-3ppc-4f35-3m26 (High), ajv GHSA-2g4f-4pwh-qvx6 (Moderate). Lockfile-only changes, no `package.json` updates needed |
+| #52 | Replace NextAuth refs with Better Auth | Incorporated | Code already aligned (env vars, function names). Cherry-picked: `totalSteps` 10→9 fix in `setup.ts`; updated stale NextAuth references in `docs/OAUTH_LOGOUT_SETUP.md` and `src/lib/providers/ministry-platform/docs/README.md` |
 
 **GitHub will show "N commits behind"** — this is expected and harmless. It reflects diverged commit history, not missing changes.
 

--- a/docs/OAUTH_LOGOUT_SETUP.md
+++ b/docs/OAUTH_LOGOUT_SETUP.md
@@ -1,15 +1,16 @@
 # OAuth Logout Configuration for Ministry Platform
 
 ## Current Status
-✅ Basic sign-out implemented using NextAuth server action  
-⚠️ OIDC RP-initiated logout not yet configured
+✅ Full sign-out implemented using Better Auth with OIDC RP-initiated logout
+✅ OIDC RP-initiated logout configured
 
 ## What's Working
-- Application-level session termination via `signOut()` server action
-- NextAuth clears local session cookies
-- User is logged out of the Next.js application
+- Application-level session termination via Better Auth sign-out
+- Better Auth clears local session cookies
+- OIDC RP-initiated logout ends Ministry Platform OAuth session
+- User is fully logged out of both the Next.js application and Ministry Platform
 
-## What's Missing (For Complete OIDC Logout)
+## Configuration Required
 
 ### 1. Ministry Platform OAuth Configuration
 You need to register **Post-Logout Redirect URIs** in your Ministry Platform OAuth client settings:
@@ -29,12 +30,13 @@ http://localhost:3000/signin
 ### 2. Implementation Details
 
 #### OIDC RP-Initiated Logout Flow:
-When a user clicks "Sign out", the current implementation:
-1. ✅ Destroys NextAuth session (JWT)
-2. ❌ Does NOT notify Ministry Platform to end the OAuth session
+When a user clicks "Sign out", the implementation:
+1. ✅ Destroys Better Auth session (JWT cookie)
+2. ✅ Redirects to Ministry Platform's end_session endpoint to terminate the OAuth session
+3. ✅ Ministry Platform redirects back to the application's post-logout URI
 
-#### To implement full logout:
-The `signOut()` function should redirect to Ministry Platform's end_session endpoint:
+#### How it works:
+The `signOut()` function redirects to Ministry Platform's end_session endpoint:
 
 ```
 ${MINISTRY_PLATFORM_BASE_URL}/oauth/connect/endsession?
@@ -47,68 +49,18 @@ ${MINISTRY_PLATFORM_BASE_URL}/oauth/connect/endsession?
 - If they click "Sign in" again, they're auto-logged back in (SSO)
 - True logout requires ending the session at both application AND identity provider
 
-### 3. Required Changes
-
-#### Store ID Token in JWT Callback:
-Already implemented in `src/auth.ts`:
-```typescript
-idToken: account.id_token,  // ✅ Line 63
-```
-
-#### Option A: Redirect-based logout (Recommended)
-Modify `signOut()` to use `redirect` parameter:
-
-```typescript
-// In user-menu/actions.ts
-export async function handleSignOut() {
-  const mpOauthUrl = `${process.env.MINISTRY_PLATFORM_BASE_URL}/oauth`;
-  const endSessionUrl = `${mpOauthUrl}/connect/endsession`;
-  
-  // Get current session to extract id_token
-  const session = await auth();
-  const idToken = session?.idToken;
-  
-  const params = new URLSearchParams({
-    post_logout_redirect_uri: process.env.NEXTAUTH_URL || 'http://localhost:3000',
-  });
-  
-  if (idToken) {
-    params.append('id_token_hint', idToken);
-  }
-  
-  // Sign out of NextAuth first
-  await signOut({ 
-    redirect: false  // Don't redirect yet
-  });
-  
-  // Then redirect to MP's end_session endpoint
-  redirect(`${endSessionUrl}?${params.toString()}`);
-}
-```
-
-#### Option B: Simple logout (Current Implementation)
-Current implementation only logs out of NextAuth locally. This is acceptable if:
-- You don't need to clear Ministry Platform session
-- Users are okay with auto-login on next visit (SSO behavior)
-
-### 4. Environment Variables
+### 3. Environment Variables
 Ensure these are set:
 
 ```env
 MINISTRY_PLATFORM_BASE_URL=https://your-mp-instance.com
-NEXTAUTH_URL=https://yourdomain.com  # Production
-NEXTAUTH_URL=http://localhost:3000   # Development
+BETTER_AUTH_URL=https://yourdomain.com  # Production
+BETTER_AUTH_URL=http://localhost:3000   # Development
 ```
 
-### 5. Testing
+### 4. Testing
 
-**Test basic logout:**
-1. Sign in to application
-2. Click "Sign out"
-3. Verify you're redirected and session is cleared
-4. Try accessing protected route - should redirect to signin
-
-**Test OIDC logout (if implemented):**
+**Test full OIDC logout:**
 1. Sign in to application
 2. Click "Sign out"
 3. Should redirect to Ministry Platform briefly
@@ -117,20 +69,13 @@ NEXTAUTH_URL=http://localhost:3000   # Development
 
 ## References
 - [OpenID Connect RP-Initiated Logout Spec](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)
-- [NextAuth.js v5 Logout Documentation](https://authjs.dev/guides/basics/signout)
+- [Better Auth Documentation](https://www.better-auth.com/)
 
-## Decision Required
+## Implementation Summary
 
-Choose implementation based on your requirements:
-
-**Option A (Full OIDC Logout):**
+**Option A (Full OIDC Logout) — Currently Implemented:**
 - Pros: True logout from identity provider, no auto-login
-- Cons: More complex, requires Ministry Platform configuration
-- Use when: Security requires clearing all sessions
+- Cons: Requires Ministry Platform configuration (Post-Logout Redirect URIs)
+- Uses Better Auth's `genericOAuth` plugin with RP-initiated logout flow
 
-**Option B (Local Logout Only - Current):**
-- Pros: Simpler, works immediately
-- Cons: SSO session remains, users auto-login
-- Use when: SSO convenience is preferred
-
-Currently implemented: **Option B**
+Currently implemented: **Option A (Full OIDC Logout)**

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -823,7 +823,7 @@ async function runInteractiveSetup(options: SetupOptions): Promise<number> {
   console.log(chalk.bold.blue('\nMPNext Setup'));
   console.log(chalk.blue('============'));
 
-  const totalSteps = 10;
+  const totalSteps = 9;
   let passedSteps = 0;
   let warnings = 0;
   let failedSteps = 0;
@@ -1235,7 +1235,7 @@ async function runInteractiveSetup(options: SetupOptions): Promise<number> {
     failedSteps++;
   }
 
-  // Step 9: Summary
+  // Summary
   console.log(chalk.bold.blue('\n\nSetup Complete!'));
   console.log(chalk.blue('==============='));
 

--- a/src/lib/providers/ministry-platform/docs/README.md
+++ b/src/lib/providers/ministry-platform/docs/README.md
@@ -27,8 +27,8 @@ ministry-platform/
 ├── provider.ts                 # Main provider class
 ├── helper.ts                   # Public API helper
 ├── auth/                       # Authentication
-│   ├── auth-provider.ts        # NextAuth provider
 │   ├── client-credentials.ts   # OAuth client credentials
+│   ├── index.ts                # Barrel export
 │   └── types.ts                # Auth-related types
 ├── services/                   # Service layer
 │   ├── table.service.ts
@@ -87,7 +87,7 @@ MINISTRY_PLATFORM_CLIENT_SECRET=your_client_secret
 - ✅ Automatic OAuth2 token management
 - ✅ Service-oriented architecture
 - ✅ Zod schema validation
-- ✅ NextAuth integration
+- ✅ Better Auth integration
 - ✅ File upload/download support
 - ✅ Comprehensive error handling
 - ✅ Clean, standards-compliant code organization


### PR DESCRIPTION
## Summary
- Incorporates upstream [PR #52](https://github.com/MinistryPlatform-Community/MPNext/pull/52) which replaces stale NextAuth references with Better Auth
- Cherry-picked: `totalSteps` 10→9 fix in `scripts/setup.ts` (step count was off by one)
- Updated stale NextAuth references in `docs/OAUTH_LOGOUT_SETUP.md` and `src/lib/providers/ministry-platform/docs/README.md`
- Updated CLAUDE.md upstream review table through PR #52

## Changes
- **`scripts/setup.ts`**: Fixed `totalSteps` from 10 to 9 (actual step count)
- **`docs/OAUTH_LOGOUT_SETUP.md`**: Rewrote to reflect current Better Auth + OIDC RP-initiated logout implementation (removed stale NextAuth code examples and "Option B" that no longer applies)
- **`src/lib/providers/ministry-platform/docs/README.md`**: Updated directory tree (removed `auth-provider.ts`, added `index.ts`) and changed "NextAuth integration" → "Better Auth integration"
- **`CLAUDE.md`**: Added PR #52 row to upstream review table, updated review date

## Security Review
- **Files reviewed**: 4 files
- **Issues found**: None
- **Checklist**: All critical/high items pass
- **Notes**: Documentation-only changes plus a step count fix — no new endpoints, no filter interpolation, no PII handling

## Test plan
- [ ] Run `npm run setup:check` — verify step counter is correct (no "Step N of 10" mismatch)
- [ ] Run `npm run build` — confirm no regressions
- [ ] Verify sign-in → sign-out flow still works (session cleared, MP end_session redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)