### PR TITLE
feat: preserve original URL through auth redirect

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -17,7 +17,9 @@ export async function proxy(request: NextRequest) {
 
     if (!sessionCookie) {
       if (isDev) console.log("Proxy: Redirecting to signin - no session cookie");
-      return NextResponse.redirect(new URL('/signin', request.url));
+      const signinUrl = new URL('/signin', request.url);
+      signinUrl.searchParams.set('callbackUrl', pathname + request.nextUrl.search);
+      return NextResponse.redirect(signinUrl);
     }
 
     if (isDev) console.log(`Proxy: Allowing request to ${pathname}`);
@@ -25,7 +27,9 @@ export async function proxy(request: NextRequest) {
 
   } catch (error) {
     console.error('Proxy: Error checking session:', error);
-    return NextResponse.redirect(new URL('/signin', request.url));
+    const signinUrl = new URL('/signin', request.url);
+    signinUrl.searchParams.set('callbackUrl', pathname + request.nextUrl.search);
+    return NextResponse.redirect(signinUrl);
   }
 }
 


### PR DESCRIPTION
## Summary
- Preserve the original URL when redirecting unauthenticated users to `/signin`
- After login, users return to their intended page instead of always landing on `/`
- Applies to both the "no session cookie" and "error checking session" redirect paths in `proxy.ts`

## Modified files
- `src/proxy.ts` — Append `?callbackUrl={pathname+search}` to signin redirects

## Security Review
- **Files reviewed**: 1 file
- **Issues found**: None
- **Checklist**: All critical/high items pass
- **Notes**: The signin page already validates callback URLs via `getSafeCallbackUrl()` which rejects absolute URLs and protocol-relative paths — no open redirect risk

## Test plan
- [x] Navigate to a protected route (e.g. `/manage-members`) while logged out — verify redirect to `/signin?callbackUrl=/manage-members`
- [x] After signing in, verify redirect back to `/manage-members` (not `/`)
- [x] Verify deep links with query params preserve the full URL (e.g. `/manage-members?member=123`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)