### PR TITLE
fix: correct photo upload form field name in member detail modal

### DIFF
--- a/src/components/manage-members/member-detail-modal.tsx
+++ b/src/components/manage-members/member-detail-modal.tsx
@@ -102,7 +102,7 @@ export function MemberDetailModal({
     try {
       const formData = new FormData();
       formData.set("Contact_ID", String(member.contactId));
-      formData.set("file", file);
+      formData.set("photo", file);
       await uploadMemberPhoto(formData);
       onUpdate();
     } catch {


### PR DESCRIPTION
## Summary
- Fix photo uploads from the Manage Members detail modal silently failing due to form field name mismatch
- The shared `uploadContactPhoto` action reads `formData.get("photo")` but the member detail modal was setting `formData.set("file", file)`
- One-line fix: `"file"` → `"photo"`

## Security Review
- **Files reviewed**: 1 file
- **Issues found**: None
- **Checklist**: All critical/high items pass
- **Notes**: No new logic, just a field name correction

## Test plan
- [ ] Upload a photo via the member detail modal avatar — verify it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)