### PR TITLE
feat: replace MP feedback with GitHub issue creation

### DIFF
--- a/.claude/ideas.md
+++ b/.claude/ideas.md
@@ -139,7 +139,7 @@ On the "New Volunteers In Process" tab, when a volunteer receives the fully appr
 On the active volunteers tab of volunteer processing, on an individuals card, list the groups where they have a role that we are tracking.
 
 ### ~~Add feedback feature ([#69](https://github.com/The-Moody-Church/mp-charts/issues/69))~~ ✅ COMPLETED
-Added a floating feedback button and modal allowing authenticated users to submit feedback to Ministry Platform's Feedback tables. Includes an admin settings page to toggle the feature, configure feedback type ID, and assign feedback to a specific contact.
+Added a floating feedback button and modal allowing authenticated users to submit feedback. Originally created MP Feedback_Entries records; replaced with GitHub issue creation in #104.
 
 ### ~~Contact-Lookup badges for Member should specify thpe ([#85](https://github.com/The-Moody-Church/mp-charts/issues/85))~~ ✅ COMPLETED
 Extracted `statusBadgeColor` to shared utility (`src/lib/contact-badge-utils.ts`), added member status badges to contact search results, and consolidated duplicate badge color functions from 3 files. Badges now show the specific MP membership type (e.g., "Registered Member", "Associate Member") in both search results and detail pages.

--- a/.claude/sessions/session-summary-2026-03-13.md
+++ b/.claude/sessions/session-summary-2026-03-13.md
@@ -1,0 +1,41 @@
+# Session Summary — 2026-03-13
+
+## Objectives
+
+- **Issue #104**: Change feedback feature from creating Ministry Platform records to creating GitHub issues
+
+## Work Log
+
+### Feedback → GitHub Issues (#104) ✅ COMPLETED
+
+Replaced the Ministry Platform Feedback_Entries integration with GitHub issue creation via the REST API.
+
+**Files modified:**
+- `src/services/feedbackService.ts` — Rewrote: removed MPHelper dependency, now creates GitHub issues via REST API with `user-feedback` label. Uses `GITHUB_FEEDBACK_TOKEN` and `GITHUB_FEEDBACK_REPO` env vars.
+- `src/components/feedback/actions.ts` — Simplified: removed MP-specific fields (contactId, mpUserId, config.feedbackTypeId, date formatting). Added `pageUrl` parameter. Gets user name from `session.user.name`.
+- `src/components/feedback/feedback-button.tsx` — Added `usePathname()` to capture current page URL, passes full URL (origin + pathname) to `submitFeedback`. Updated dialog description text.
+- `src/lib/feedback-config-types.ts` — Simplified `FeedbackConfig` to just `{ enabled: boolean }`. Removed `feedbackTypeId` and `assignedToContactId`.
+- `src/lib/feedback-config.ts` — Updated `isFeedbackEnabled()` to check `config.enabled && !!process.env.GITHUB_FEEDBACK_TOKEN`. Removed MP-specific default config fields.
+- `src/components/admin/feedback/feedback-settings.tsx` — Removed "Ministry Platform Settings" fieldset (feedback type dropdown, assigned contact input). Added "GitHub Integration" fieldset showing token configuration status.
+- `src/components/admin/feedback/actions.ts` — Removed `getFeedbackTypes()` MP query. Added `getGitHubTokenConfigured()`. Simplified `saveFeedbackConfigAction` (no feedbackTypeId required check).
+- `data/feedback-config.json` — Simplified to `{ "enabled": true }`.
+- `.env.example` — Added `GITHUB_FEEDBACK_TOKEN` and `GITHUB_FEEDBACK_REPO` env vars with documentation.
+- `README.md` — Updated feedback and FeedbackService descriptions.
+
+**Files unchanged (no modifications needed):**
+- `src/components/feedback/feedback-wrapper.tsx` — Still checks `feedbackEnabled` from user context
+- `src/components/feedback/index.ts` — Barrel exports unchanged
+- `src/components/shared-actions/user.ts` — Already calls `isFeedbackEnabled()` which now checks for GitHub token
+- `src/contexts/user-context.tsx` — `feedbackEnabled` state unchanged
+
+**Context files updated:**
+- `.claude/ideas.md` — Updated #69 description to note GitHub issue replacement
+- `.claude/status.md` — Added #104 to recently completed
+- `README.md` — Updated feedback descriptions
+
+**Key decisions:**
+- Used GitHub REST API with `fetch()` directly — no new npm dependency needed
+- Kept the admin enable/disable toggle + requires `GITHUB_FEEDBACK_TOKEN` env var (both must be true)
+- Added `user-feedback` label to all created issues for easy filtering
+- Issue body format: description (if provided), then separator, then page URL and submitter name
+- `getInstance()` changed from `async` to sync since no MPHelper initialization needed

--- a/.claude/status.md
+++ b/.claude/status.md
@@ -2,12 +2,13 @@
 
 Quick-reference snapshot of current project state. Read this first at session start. For full details on any item, see the relevant session summary in `.claude/sessions/`.
 
-**Last updated**: 2026-03-12
+**Last updated**: 2026-03-13
 
 ## Recently Completed
 
 | Date | Work | Issues | PR |
 |------|------|--------|---|
+| 2026-03-13 | **Feedback → GitHub issues**: Replaced MP Feedback_Entries with GitHub issue creation. Simplified config (removed feedbackTypeId/assignedToContactId), added GITHUB_FEEDBACK_TOKEN env var, appends page URL + user name to issues, admin shows token status. | #104 | — |
 | 2026-03-12 | **Restrict contact log edit by owner**: Edit button and server action only allow editing logs created by the current user (Made_By check). Added "Logged by" display showing who created each log entry. | #96 | — |
 | 2026-03-12 | **Contact search null safety & scoring**: Fixed localeCompare crash on null Last_Name/First_Name (#99), added proportional prefix-match bonus to search scoring (#98) | #98, #99 | #101 |
 | 2026-03-12 | **Optimize dashboard cache queries**: Activity_Log uses per-month parallel queries with `$distinct`+`$groupby` and `Page_ID <> 316`; Monthly attendance trends parallelized (~48 sequential calls → 12 parallel pairs × 2 years) | #97 | #100 |

--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,11 @@ NEXT_PUBLIC_APP_NAME=MP Tools
 # Super-admin User Group IDs — comma-separated
 # Users in ANY of these groups have full access to all features + admin page
 ADMIN_USER_GROUP_IDS=29
+
+# GitHub Feedback Configuration
+# PAT with `repo` or `public_repo` scope — required for the feedback feature
+# Generate at: https://github.com/settings/tokens
+GITHUB_FEEDBACK_TOKEN=
+# Repository where feedback issues are created (owner/repo format)
+# Defaults to The-Moody-Church/mp-charts if not set
+# GITHUB_FEEDBACK_REPO=The-Moody-Church/mp-charts

--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ Built with Radix UI primitives and styled with Tailwind CSS. Located in `src/com
 - **manage-members**: Membership status management with card grid, tab filtering, detail modal (expandable milestones with notes/files, deep links, contact actions), optimistic status transitions with cache invalidation
 - **compliance-processing**: Configurable compliance tracking workflows (e.g., membership)
 - **admin**: Admin tool editors for journey and compliance tool configuration
-- **feedback**: User feedback submission
+- **feedback**: User feedback submission (creates GitHub issues)
 - **processing**: Shared processing components (PersonAvatar, ProcessingGrid, MilestoneEditForm)
 - **pwa**: Progressive Web App install prompt
 - **user-menu**: User profile dropdown with sign-out
@@ -503,10 +503,10 @@ Application services provide business logic abstraction over the Ministry Platfo
 | **JourneyProcessingService** | `journeyProcessingService.ts` | Journey workflow step processing |
 | **ComplianceProcessingService** | `complianceProcessingService.ts` | Compliance workflow processing |
 | **MemberService** | `memberService.ts` | Membership status management, milestones, transitions |
-| **FeedbackService** | `feedbackService.ts` | User feedback submission |
+| **FeedbackService** | `feedbackService.ts` | User feedback (creates GitHub issues) |
 | **UserService** | `userService.ts` | User profile and roles retrieval |
 
-All services follow the singleton pattern and use `MPHelper` for API communication.
+Most services follow the singleton pattern and use `MPHelper` for API communication. `FeedbackService` uses the GitHub REST API instead.
 
 ## Testing
 

--- a/src/components/admin/feedback/actions.ts
+++ b/src/components/admin/feedback/actions.ts
@@ -7,7 +7,6 @@ import {
   validateFeedbackConfig,
 } from "@/lib/feedback-config";
 import type { FeedbackConfig } from "@/lib/feedback-config";
-import { MPHelper } from "@/lib/providers/ministry-platform";
 import { z } from "zod";
 
 export async function getFeedbackConfig(): Promise<FeedbackConfig> {
@@ -21,10 +20,6 @@ export async function saveFeedbackConfigAction(
   try {
     await requireFeatureAccess("admin");
     validateFeedbackConfig(config);
-
-    if (config.enabled && !config.feedbackTypeId) {
-      return { success: false, error: "Feedback Type ID is required when feedback is enabled." };
-    }
 
     saveFeedbackConfig(config);
     return { success: true };
@@ -44,19 +39,11 @@ export async function saveFeedbackConfigAction(
   }
 }
 
-export async function getFeedbackTypes(): Promise<
-  { Feedback_Type_ID: number; Feedback_Type: string }[]
-> {
+/**
+ * Check whether the GITHUB_FEEDBACK_TOKEN env var is set.
+ * Used by the admin UI to show configuration status.
+ */
+export async function getGitHubTokenConfigured(): Promise<boolean> {
   await requireFeatureAccess("admin");
-  const mp = new MPHelper();
-  const records = await mp.getTableRecords<{
-    Feedback_Type_ID: number;
-    Feedback_Type: string;
-  }>({
-    table: "Feedback_Types",
-    select: "Feedback_Type_ID,Feedback_Type",
-    top: 100,
-    orderBy: "Feedback_Type",
-  });
-  return records;
+  return !!process.env.GITHUB_FEEDBACK_TOKEN;
 }

--- a/src/components/admin/feedback/feedback-settings.tsx
+++ b/src/components/admin/feedback/feedback-settings.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { ArrowLeft } from "lucide-react";
@@ -11,18 +10,14 @@ import type { FeedbackConfig } from "@/lib/feedback-config-types";
 import {
   getFeedbackConfig,
   saveFeedbackConfigAction,
-  getFeedbackTypes,
+  getGitHubTokenConfigured,
 } from "./actions";
 
 export function FeedbackSettings() {
   const [config, setConfig] = useState<FeedbackConfig>({
     enabled: false,
-    feedbackTypeId: null,
-    assignedToContactId: null,
   });
-  const [feedbackTypes, setFeedbackTypes] = useState<
-    { Feedback_Type_ID: number; Feedback_Type: string }[]
-  >([]);
+  const [tokenConfigured, setTokenConfigured] = useState(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -31,12 +26,12 @@ export function FeedbackSettings() {
   useEffect(() => {
     async function load() {
       try {
-        const [cfg, types] = await Promise.all([
+        const [cfg, hasToken] = await Promise.all([
           getFeedbackConfig(),
-          getFeedbackTypes(),
+          getGitHubTokenConfigured(),
         ]);
         setConfig(cfg);
-        setFeedbackTypes(types);
+        setTokenConfigured(hasToken);
       } catch (err) {
         setError(
           err instanceof Error ? err.message : "Failed to load feedback config."
@@ -117,56 +112,23 @@ export function FeedbackSettings() {
 
         <fieldset className="space-y-4 rounded-lg border p-4">
           <legend className="px-2 text-sm font-medium">
-            Ministry Platform Settings
+            GitHub Integration
           </legend>
 
           <div className="space-y-2">
-            <Label htmlFor="feedback-type">Feedback Type</Label>
-            <select
-              id="feedback-type"
-              className="flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base sm:text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-              value={config.feedbackTypeId ?? ""}
-              onChange={(e) =>
-                setConfig({
-                  ...config,
-                  feedbackTypeId: e.target.value
-                    ? Number(e.target.value)
-                    : null,
-                })
-              }
-            >
-              <option value="">Select a feedback type...</option>
-              {feedbackTypes.map((ft) => (
-                <option key={ft.Feedback_Type_ID} value={ft.Feedback_Type_ID}>
-                  {ft.Feedback_Type}
-                </option>
-              ))}
-            </select>
+            <Label>GitHub Token Status</Label>
+            {tokenConfigured ? (
+              <p className="text-sm text-green-600">
+                GITHUB_FEEDBACK_TOKEN is configured. Feedback submissions will create GitHub issues.
+              </p>
+            ) : (
+              <p className="text-sm text-amber-600">
+                GITHUB_FEEDBACK_TOKEN is not set. Add it to your environment variables to enable feedback.
+              </p>
+            )}
             <p className="text-xs text-muted-foreground">
-              The feedback type assigned to all submissions
-            </p>
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="assigned-contact">
-              Assigned To (Contact ID)
-            </Label>
-            <Input
-              id="assigned-contact"
-              type="number"
-              placeholder="Optional — Contact ID to assign feedback to"
-              value={config.assignedToContactId ?? ""}
-              onChange={(e) =>
-                setConfig({
-                  ...config,
-                  assignedToContactId: e.target.value
-                    ? Number(e.target.value)
-                    : null,
-                })
-              }
-            />
-            <p className="text-xs text-muted-foreground">
-              All feedback entries will be assigned to this contact for review
+              Feedback submissions create issues on the configured GitHub repository
+              (GITHUB_FEEDBACK_REPO, defaults to The-Moody-Church/mp-charts).
             </p>
           </div>
         </fieldset>

--- a/src/components/feedback/actions.ts
+++ b/src/components/feedback/actions.ts
@@ -1,13 +1,14 @@
 "use server";
 
-import { requireSession, getMpUserId, getMpContactId } from "@/lib/auth-helpers";
+import { requireSession } from "@/lib/auth-helpers";
 import { enforceRateLimit } from "@/lib/rate-limit";
-import { loadFeedbackConfig, isFeedbackEnabled } from "@/lib/feedback-config";
+import { isFeedbackEnabled } from "@/lib/feedback-config";
 import { FeedbackService } from "@/services/feedbackService";
 
 export async function submitFeedback(
   title: string,
-  description: string
+  description: string,
+  pageUrl: string
 ): Promise<{ success: boolean; error?: string }> {
   try {
     const session = await requireSession();
@@ -30,57 +31,22 @@ export async function submitFeedback(
       return { success: false, error: "Description must be 2000 characters or less." };
     }
 
-    const contactId = getMpContactId(session);
-    if (!contactId) {
-      return { success: false, error: "Could not determine your contact ID." };
-    }
+    const userName = session.user.name || "Unknown User";
 
-    const mpUserId = getMpUserId(session);
-    if (!mpUserId) {
-      return { success: false, error: "Could not determine your user ID." };
-    }
-
-    const config = loadFeedbackConfig();
-
-    // Date submitted in Central Time
-    const now = new Date();
-    const centralDate = now.toLocaleString("en-US", {
-      timeZone: "America/Chicago",
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-      hour12: false,
+    const feedbackService = FeedbackService.getInstance();
+    await feedbackService.createFeedbackIssue({
+      title: trimmedTitle,
+      description: trimmedDescription || null,
+      pageUrl,
+      userName,
     });
-    // Convert "MM/DD/YYYY, HH:mm:ss" to ISO-like format for MP
-    const [datePart, timePart] = centralDate.split(", ");
-    const [month, day, year] = datePart.split("/");
-    const dateSubmitted = `${year}-${month}-${day}T${timePart}`;
-
-    const feedbackService = await FeedbackService.getInstance();
-    await feedbackService.createFeedbackEntry(
-      {
-        Contact_ID: contactId,
-        Entry_Title: trimmedTitle,
-        Feedback_Type_ID: config.feedbackTypeId!,
-        Date_Submitted: dateSubmitted,
-        Visibility_Level_ID: 2,
-        Description: trimmedDescription || null,
-        Ongoing_Need: false,
-        Assigned_To: config.assignedToContactId,
-        Approved: false,
-      },
-      mpUserId
-    );
 
     return { success: true };
   } catch (error) {
     console.error("Error submitting feedback:", error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : "Failed to submit feedback.",
+      error: "Failed to submit feedback. Please try again later.",
     };
   }
 }

--- a/src/components/feedback/feedback-button.tsx
+++ b/src/components/feedback/feedback-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { usePathname } from "next/navigation";
 import { MessageSquarePlus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -17,6 +18,7 @@ import {
 import { submitFeedback } from "./actions";
 
 export function FeedbackButton() {
+  const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
@@ -34,7 +36,8 @@ export function FeedbackButton() {
 
     setSubmitting(true);
     try {
-      const result = await submitFeedback(title, description);
+      const pageUrl = `${window.location.origin}${pathname}`;
+      const result = await submitFeedback(title, description, pageUrl);
       if (!result.success) {
         setError(result.error || "Failed to submit feedback.");
         return;
@@ -84,7 +87,7 @@ export function FeedbackButton() {
           <DialogHeader>
             <DialogTitle>Give Feedback</DialogTitle>
             <DialogDescription>
-              Share a suggestion or idea. Your feedback is submitted to the team.
+              Share a suggestion or idea. Your feedback creates a GitHub issue for the team to review.
             </DialogDescription>
           </DialogHeader>
 

--- a/src/lib/feedback-config-types.ts
+++ b/src/lib/feedback-config-types.ts
@@ -6,8 +6,6 @@ import { z } from "zod";
 
 export interface FeedbackConfig {
   enabled: boolean;
-  feedbackTypeId: number | null;
-  assignedToContactId: number | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -16,8 +14,6 @@ export interface FeedbackConfig {
 
 export const FeedbackConfigSchema = z.object({
   enabled: z.boolean(),
-  feedbackTypeId: z.number().int().positive().nullable(),
-  assignedToContactId: z.number().int().positive().nullable(),
 });
 
 export function validateFeedbackConfig(data: unknown): FeedbackConfig {

--- a/src/lib/feedback-config.ts
+++ b/src/lib/feedback-config.ts
@@ -17,8 +17,6 @@ const CONFIG_PATH = join(process.cwd(), "data", "feedback-config.json");
 
 const DEFAULT_CONFIG: FeedbackConfig = {
   enabled: false,
-  feedbackTypeId: null,
-  assignedToContactId: null,
 };
 
 /**
@@ -46,8 +44,11 @@ export function saveFeedbackConfig(config: FeedbackConfig): void {
   writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n", "utf-8");
 }
 
-/** Returns true if feedback is enabled and properly configured. */
+/**
+ * Returns true if feedback is enabled and the GitHub token is configured.
+ * Requires both the admin toggle AND the GITHUB_FEEDBACK_TOKEN env var.
+ */
 export function isFeedbackEnabled(): boolean {
   const config = loadFeedbackConfig();
-  return config.enabled && config.feedbackTypeId !== null;
+  return config.enabled && !!process.env.GITHUB_FEEDBACK_TOKEN;
 }

--- a/src/services/feedbackService.ts
+++ b/src/services/feedbackService.ts
@@ -1,32 +1,93 @@
-import { MPHelper } from "@/lib/providers/ministry-platform";
-import type { FeedbackEntries } from "@/lib/providers/ministry-platform/models/FeedbackEntries";
+/**
+ * FeedbackService — creates GitHub issues from user feedback.
+ *
+ * Requires environment variables:
+ *   GITHUB_FEEDBACK_TOKEN  — GitHub PAT with `repo` or `public_repo` scope
+ *   GITHUB_FEEDBACK_REPO   — owner/repo (defaults to "The-Moody-Church/mp-charts")
+ */
+
+const DEFAULT_REPO = "The-Moody-Church/mp-charts";
+
+interface CreateIssueParams {
+  title: string;
+  description: string | null;
+  pageUrl: string;
+  userName: string;
+}
+
+interface GitHubIssueResponse {
+  number: number;
+  html_url: string;
+}
 
 export class FeedbackService {
   private static instance: FeedbackService;
-  private mp: MPHelper | null = null;
+  private token: string;
+  private repo: string;
 
-  private constructor() {}
+  private constructor(token: string, repo: string) {
+    this.token = token;
+    this.repo = repo;
+  }
 
-  public static async getInstance(): Promise<FeedbackService> {
+  public static getInstance(): FeedbackService {
     if (!FeedbackService.instance) {
-      FeedbackService.instance = new FeedbackService();
-      FeedbackService.instance.mp = new MPHelper();
+      const token = process.env.GITHUB_FEEDBACK_TOKEN;
+      if (!token) {
+        throw new Error("GITHUB_FEEDBACK_TOKEN environment variable is not set.");
+      }
+      const repo = process.env.GITHUB_FEEDBACK_REPO || DEFAULT_REPO;
+      FeedbackService.instance = new FeedbackService(token, repo);
     }
     return FeedbackService.instance;
   }
 
   /**
-   * Create a feedback entry in Ministry Platform.
+   * Create a GitHub issue from user feedback.
    */
-  public async createFeedbackEntry(
-    record: Omit<FeedbackEntries, "Feedback_Entry_ID">,
-    userId: number
-  ): Promise<FeedbackEntries> {
-    const results = await this.mp!.createTableRecords(
-      "Feedback_Entries",
-      [record],
-      { $userId: userId }
+  public async createFeedbackIssue(
+    params: CreateIssueParams
+  ): Promise<GitHubIssueResponse> {
+    const { title, description, pageUrl, userName } = params;
+
+    // Build issue body with description, page URL, and submitter name
+    const bodyParts: string[] = [];
+    if (description) {
+      bodyParts.push(description);
+    }
+    bodyParts.push("");
+    bodyParts.push("---");
+    bodyParts.push(`**Page:** ${pageUrl}`);
+    bodyParts.push(`**Submitted by:** ${userName}`);
+
+    const body = bodyParts.join("\n");
+
+    const response = await fetch(
+      `https://api.github.com/repos/${this.repo}/issues`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+          Accept: "application/vnd.github+json",
+          "Content-Type": "application/json",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+        body: JSON.stringify({
+          title,
+          body,
+          labels: ["user-feedback"],
+        }),
+      }
     );
-    return (results as unknown as FeedbackEntries[])[0];
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `GitHub API error (${response.status}): ${errorText}`
+      );
+    }
+
+    const data = (await response.json()) as GitHubIssueResponse;
+    return data;
   }
 }


### PR DESCRIPTION
## Summary
- Replaces Ministry Platform `Feedback_Entries` integration with GitHub REST API issue creation
- Feedback submissions now create labeled (`user-feedback`) GitHub issues with page URL and submitter name appended
- Simplifies admin settings — removed MP-specific fields, shows GitHub token configuration status

Closes #104

## Setup Required
- Set `GITHUB_FEEDBACK_TOKEN` env var with a GitHub PAT that has `repo` scope
- Optionally set `GITHUB_FEEDBACK_REPO` (defaults to `The-Moody-Church/mp-charts`)
- Create a `user-feedback` label in the target repo

## Security Review
- **Files reviewed**: 12 files
- **Issues found**: 1 medium (fixed) — GitHub API error details were leaking to client; now returns generic error message
- **Checklist**: All critical/high items pass
- **Notes**: `pageUrl` from client is not validated (only embedded in issue body text, not used for redirects — low risk since submitter name is also recorded)

## Test plan
- [ ] Set `GITHUB_FEEDBACK_TOKEN` env var and verify feedback button creates GitHub issues
- [ ] Verify issue body contains description, page URL, and submitter name
- [ ] Verify admin feedback settings page shows token status correctly
- [ ] Test with token missing — feedback button should not appear
- [ ] Test error handling — submit with invalid token, verify generic error shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)