### PR TITLE
fix #116: add close button to contact detail card

### DIFF
--- a/.claude/ideas.md
+++ b/.claude/ideas.md
@@ -25,6 +25,7 @@ Ideas and enhancements for the MPNext project. This file syncs bidirectionally w
 - ~~[Contact-Lookup badges for Member should specify thpe (#85)](#contact-lookup-badges-for-member-should-specify-thpe-85)~~ ✅
 
 ### Improvements
+- ~~[Add "X" to the top right of the contact card (#116)](#add-x-to-the-top-right-of-the-contact-card-116)~~ ✅
 - [Serving metrics: reconcile adult-only vs all-ages counts (#110)](#serving-metrics-reconcile-adult-only-vs-all-ages-counts-110)
 - ~~[Small Group Trends Chart (#15)](#small-group-trends-chart-15)~~ ✅
 - ~~[contact lookup search improvements (#94)](#contact-lookup-search-improvements-94)~~ ✅
@@ -152,6 +153,9 @@ Extracted `statusBadgeColor` to shared utility (`src/lib/contact-badge-utils.ts`
 
 ### Serving metrics: reconcile adult-only vs all-ages counts ([#110](https://github.com/The-Moody-Church/mp-charts/issues/110))
 The Engagement Overview Venn diagram filters serving/leading to **adults only** (18+ or unknown birthdate), showing ~830. The Grow in Love section's "Serving by Role Type" counts **all ages**, showing ~1,022. The ~192-person gap is minors with active serving/leading roles (e.g., student volunteers). Need to decide: should the Grow in Love charts also filter to adults, or should the Venn diagram include all ages? Or add an "(all ages)" note to the Grow in Love description to make the difference explicit?
+
+### ~~Add "X" to the top right of the contact card ([#116](https://github.com/The-Moody-Church/mp-charts/issues/116))~~ ✅ COMPLETED
+When viewing contact details, added an "X" close button to the top right of the contact card that returns the user to the search page.
 
 ### ~~Small Group Trends Chart ([#15](https://github.com/The-Moody-Church/mp-charts/issues/15))~~ ✅ COMPLETED
 

--- a/.claude/sessions/session-summary-2026-03-17.md
+++ b/.claude/sessions/session-summary-2026-03-17.md
@@ -1,0 +1,22 @@
+# Session Summary — 2026-03-17
+
+## Objectives
+- Address newly created issue #116: Add close button ("X") to contact detail card
+
+## Issues Addressed
+- **#116** — Add "X" to the top right of the contact card ✅ COMPLETED
+
+## Changes
+
+### Modified Files
+- `src/components/contact-lookup-details/contact-lookup-details.tsx` — Added close button (Link to `/contact-lookup`) positioned absolute top-right of the contact card. Uses existing `Link` import, styled with gray hover state and proper `aria-label`.
+
+### Context Files Updated
+- `.claude/ideas.md` — Added #116 entry as completed in Improvements TOC and body
+- `.claude/status.md` — Added 2026-03-17 entry for #116
+- `.claude/sessions/session-summary-2026-03-17.md` — This file
+
+## Decisions
+- Used `Link` component (not `router.push` or `router.back`) so the close button always navigates to `/contact-lookup` regardless of navigation history
+- Positioned the button absolute within a relative card container for clean top-right placement
+- Used responsive padding (`top-3 right-3 sm:top-4 sm:right-4`) to align with card padding

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,7 +20,8 @@
       "Bash(wc *)",
       "Bash(ls:*)",
       "Bash(head:*)",
-      "Bash(mkdir:*)"
+      "Bash(mkdir:*)",
+      "Bash(cat:*)"
     ],
     "deny": [],
     "ask": [],

--- a/.claude/status.md
+++ b/.claude/status.md
@@ -2,12 +2,13 @@
 
 Quick-reference snapshot of current project state. Read this first at session start. For full details on any item, see the relevant session summary in `.claude/sessions/`.
 
-**Last updated**: 2026-03-16
+**Last updated**: 2026-03-17
 
 ## Recently Completed
 
 | Date | Work | Issues | PR |
 |------|------|--------|---|
+| 2026-03-17 | **Contact card close button**: Added "X" button to top-right of contact detail card to return to search. | #116 | — |
 | 2026-03-16 | **Contact search: wait for Enter**: Removed debounced search-as-you-type that caused laggy flashing results. Search now fires on Enter/click only. | #112 | — |
 | 2026-03-16 | **Stable cache keys**: Changed dashboard cache keys from today's date to end-of-ministry-year (Aug 31) so they're stable all year. Eliminates daily cold cache at midnight. Service methods cap month iteration at today to avoid wasted API calls. | #113 | #114 |
 | 2026-03-15 | **Concurrency control**: Added `mapWithConcurrency` (limit 6) to monthly attendance API calls. Prevents 55+ parallel requests from overwhelming MP API. | — | — |

--- a/src/components/contact-lookup-details/contact-lookup-details.tsx
+++ b/src/components/contact-lookup-details/contact-lookup-details.tsx
@@ -289,7 +289,16 @@ export const ContactLookupDetails: React.FC<ContactLookupDetailsProps> = ({
 
   return (
     <>
-      <div className="bg-white shadow rounded-lg">
+      <div className="bg-white shadow rounded-lg relative">
+        <Link
+          href="/contact-lookup"
+          className="absolute top-3 right-3 sm:top-4 sm:right-4 p-1 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+          aria-label="Close contact card"
+        >
+          <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </Link>
         <div className="px-4 py-5 sm:p-6">
           {/* Header: Avatar + Name + Badges */}
           <div className="flex items-center space-x-5">


### PR DESCRIPTION
## Summary
- Adds an "X" close button to the top-right corner of the contact detail card
- Clicking it navigates back to `/contact-lookup` (the search page)
- Uses a `Link` component with responsive positioning that aligns with the card's padding

Closes #116

## Security Review
- **Files reviewed**: 1 code file (contact-lookup-details.tsx)
- **Issues found**: None — static `Link` with hardcoded href, no user input or data access
- **Checklist**: All critical/high items pass

## Test plan
- [ ] Open a contact detail page (e.g., `/contact-lookup/<guid>`)
- [ ] Verify the "X" button appears in the top-right corner of the white card
- [ ] Click the X — should navigate to `/contact-lookup`
- [ ] Test on mobile viewport — button should stay visible and tappable

🤖 Generated with [Claude Code](https://claude.com/claude-code)