### PR TITLE
Fix cache stale-while-revalidate serving cold misses

### DIFF
--- a/.claude/sessions/session-summary-2026-03-23.md
+++ b/.claude/sessions/session-summary-2026-03-23.md
@@ -2,12 +2,21 @@
 
 ## Objectives
 - Create PR for contact card badges and household position labels
+- Fix cache stale-while-revalidate not serving stale data (#124, #125, #127)
 
 ## Work Done
 - ✅ PR #126 created, tested, merged, deployed
 - ✅ Fixed two ambiguous column name errors in MP queries (Household_Position_ID, Start_Date/End_Date)
+- ✅ Fixed cache refresh actions purging stale data instead of triggering background revalidation (#124, #125, #127)
 
 ## Changes
+
+### Session 2 — Cache stale-while-revalidate fix
+- **`src/components/manage-members/actions.ts`** — Changed `revalidateTag('contacts-search', { expire: 0 })` → `updateTag('contacts-search')` so stale data is served while revalidating
+- **`src/components/dashboard/actions.ts`** — Changed `revalidateTag('dashboard-data', { expire: 0 })` and `revalidateTag('group-types', { expire: 0 })` → `updateTag()` equivalents
+- **`CLAUDE.md`** — Updated cache invalidation docs to recommend `updateTag` as default
+
+### Session 1 — Contact card badges
 - **`src/services/contactService.ts`** — Added `getAgeGradeGroupNames()` method; wired into `getContactBadges()`; qualified ambiguous columns in household and age/grade queries
 - **`src/components/contact-lookup-details/contact-lookup-details.tsx`** — Render violet age/grade badges; show household position labels
 - **`src/components/contact-lookup-details/actions.ts`** — Pass `householdPositionId` through to service
@@ -17,3 +26,4 @@
 - Age/grade groups only fetched for Minor Child contacts (Household_Position_ID = 2) to avoid unnecessary API calls
 - Household position text fetched via join (`Household_Position_ID_Table.[Household_Position]`) rather than separate lookup
 - Added feedback memory: always qualify column names in MP queries with table joins
+- `revalidateTag` with `{ expire: 0 }` purges cache entirely (cold miss); `updateTag` marks stale and serves existing data while revalidating in background — the correct behavior for user-facing refresh actions

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,6 +1,5 @@
 {
   "permissions": {
-    "defaultMode": "auto",
     "allow": [
       "Read",
       "Edit",
@@ -27,10 +26,13 @@
       "Bash(kill:*)",
       "Bash(find /Users/jonathon.huff/Claude/Code/mp-charts/mp-charts -type f \\\\\\(-name *.yml -o -name *.yaml -o -name Dockerfile* -o -name docker-compose* -o -name .trivy* -o -name .snyk* \\\\\\))",
       "Bash(find /Users/jonathon.huff/Claude/Code/mp-charts/mp-charts -type f \\\\\\(-name *scan* -o -name *security* -o -name *audit* -o -name *.trivy* -o -name *.snyk* \\\\\\))",
-      "Bash(git add:*)"
+      "Bash(git add:*)",
+      "Bash(grep -r \"revalidateTag\\\\|revalidatePath\\\\|contacts-search\" /Users/jonathon.huff/Claude/Code/mp-charts/mp-charts/src --include=*.ts --include=*.tsx)",
+      "Bash(grep -A 10 -B 5 \"connection\\\\|''''use cache''''\" /Users/jonathon.huff/Claude/Code/mp-charts/mp-charts/src/components/dashboard/*.tsx)"
     ],
     "deny": [],
     "ask": [],
+    "defaultMode": "auto",
     "additionalDirectories": [
       "/Users/jonathon.huff/.claude/plans",
       "/Users/jonathon.huff/Claude/Code/choir-seating-chart/.github/workflows"

--- a/.claude/status.md
+++ b/.claude/status.md
@@ -8,6 +8,7 @@ Quick-reference snapshot of current project state. Read this first at session st
 
 | Date | Work | Issues | PR |
 |------|------|--------|---|
+| 2026-03-23 | **Fix cache stale-while-revalidate**: Changed `revalidateTag({expire:0})` → `updateTag()` so dashboard and contact cache refreshes serve stale data instantly instead of causing 20-30s cold misses. | #124, #125, #127 | TBD |
 | 2026-03-23 | **Contact card: age/grade badges & household positions**: Violet badges for minor children's age/grade groups; household position labels under each member. | — | #126 |
 | 2026-03-18 | **Auto contact logging**: Clicking email/phone/text/directions or copying email/phone/address on contact card auto-creates a Contact Log entry. | #121 | #120 |
 | 2026-03-18 | **CI: npm audit step** + **Dependabot security alerts** enabled. Added `npm audit --audit-level=high` to Docker build workflow. | — | — |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,7 @@ async function getCachedData(key: string) {
 **Rules for `'use cache'` functions:**
 - `new Date()` and other non-deterministic expressions must stay OUTSIDE the function — pass as serializable parameters
 - Function arguments automatically become the cache key
-- Invalidate with `revalidateTag('my-tag', { expire: 0 })` from server actions
+- Invalidate with `updateTag('my-tag')` from server actions (serves stale data while revalidating in background; use `revalidateTag('my-tag', { expire: 0 })` only when stale data must NOT be served)
 
 **Current cached functions:**
 | Function | Revalidate | Stale | Tags | File |

--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { revalidatePath, revalidateTag } from 'next/cache';
+import { revalidatePath, updateTag } from 'next/cache';
 import { requireFeatureAccess } from '@/lib/authorization';
 import { enforceRateLimit } from '@/lib/rate-limit';
 import { DashboardData } from '@/lib/dto';
@@ -114,8 +114,8 @@ export async function refreshDashboardCache(): Promise<{
     enforceRateLimit(session.user.id, "cacheRefresh");
 
     revalidatePath('/dashboard');
-    revalidateTag('dashboard-data', { expire: 0 });
-    revalidateTag('group-types', { expire: 0 });
+    updateTag('dashboard-data');
+    updateTag('group-types');
     return {
       success: true,
       timestamp: new Date()

--- a/src/components/manage-members/actions.ts
+++ b/src/components/manage-members/actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { revalidateTag } from "next/cache";
+import { updateTag } from "next/cache";
 import { requireFeatureAccess } from "@/lib/authorization";
 import { getMpUserId } from "@/lib/auth-helpers";
 import { enforceRateLimit } from "@/lib/rate-limit";
@@ -226,7 +226,7 @@ export async function refreshMemberCache(): Promise<{ success: boolean; error?: 
   try {
     const session = await requireFeatureAccess("manage-members");
     enforceRateLimit(session.user.id, "cacheRefresh");
-    revalidateTag('contacts-search', { expire: 0 });
+    updateTag('contacts-search');
     return { success: true };
   } catch (error) {
     return {


### PR DESCRIPTION
## Summary
- Replaced `revalidateTag(tag, { expire: 0 })` with `updateTag(tag)` in both dashboard and contact cache refresh actions
- `revalidateTag` with `{ expire: 0 }` **purges** cached data entirely — next request hits a cold cache (20-30s fetch from Ministry Platform API)
- `updateTag` marks entries as stale but **continues serving existing data instantly** while a background revalidation happens
- Updated CLAUDE.md cache invalidation docs to recommend `updateTag` as the default pattern

## Files Changed
| File | Change |
|------|--------|
| `src/components/manage-members/actions.ts` | `revalidateTag → updateTag` for `contacts-search` |
| `src/components/dashboard/actions.ts` | `revalidateTag → updateTag` for `dashboard-data` and `group-types` |
| `CLAUDE.md` | Updated cache invalidation guidance |

## Security Review
- **Files reviewed**: 3 source files
- **Issues found**: None
- **Checklist**: All critical/high items pass — no filter params, no redirects, no auth changes, no PII logging, no secrets
- **Notes**: Changes are limited to cache invalidation strategy; no new endpoints or data access patterns

## Test plan
- [ ] Start dev server, navigate to Contact Lookup, perform a search — results should load from warm cache
- [ ] Click "Refresh Cache" on the dashboard — page should respond instantly with existing data, then show fresh data on next load
- [ ] Click "Refresh Cache" on manage-members — search should still return results instantly (stale), not show a 20-30s delay
- [ ] Verify cache warming still works on server start (check console for `[instrumentation] Cache warming complete`)

Fixes #124, #125, #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)