### PR TITLE
fix: custom cache handler to enable stale-while-revalidate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,14 @@ When adding, removing, or renaming environment variables, update `.env.example` 
 
 The project uses **Cache Components** (`cacheComponents: true`) with **Partial Prerendering (PPR)**. All authenticated pages render as `◐ (Partial Prerender)` — the static HTML shell loads instantly, then dynamic content streams in via Suspense boundaries.
 
+### Custom Cache Handler
+
+**IMPORTANT**: The default Next.js in-memory cache handler **ignores `cacheLife({ stale })` entirely**. It expires entries at `revalidate` time (6h) and returns `undefined` — a full cache miss — instead of serving stale data. This caused 30+ second cold cache fetches every 6 hours.
+
+A custom handler at `cache-handler.js` (configured via `cacheHandlers.default` in `next.config.ts`) fixes this by using the `expire` field (revalidate + stale = 30h) as the true expiry. Between 6h and 30h, it returns cached data with `revalidate: -1`, which tells the framework to serve stale data instantly while revalidating in the background.
+
+**Note**: The cache is still in-memory (LRU, 50MB). Container restarts wipe the cache — cache warming on startup (`instrumentation.ts`) repopulates it within ~60s. The custom handler ensures stale-while-revalidate works correctly *within* a container's lifetime.
+
 ### `'use cache'` Directive
 
 Data-fetching functions use the `'use cache'` directive with `cacheLife()` and `cacheTag()` from `next/cache`:

--- a/cache-handler.js
+++ b/cache-handler.js
@@ -1,0 +1,158 @@
+/**
+ * Custom cache handler that properly supports stale-while-revalidate.
+ *
+ * The default Next.js in-memory handler expires entries at `revalidate` time
+ * (6h in our case), completely ignoring the `stale` parameter. After 6 hours,
+ * the cache returns undefined — a full miss — causing 30+ second cold fetches.
+ *
+ * This handler uses `expire` (revalidate + stale = 30h) as the true expiry.
+ * Between revalidate (6h) and expire (30h), it returns the cached entry with
+ * revalidate: -1, which tells the framework to serve stale data instantly
+ * while revalidating in the background.
+ *
+ * Configured via next.config.ts → cacheHandlers.default
+ */
+
+const { LRUCache } = require('next/dist/server/lib/lru-cache');
+const {
+  tagsManifest,
+  areTagsExpired,
+  areTagsStale,
+} = require('next/dist/server/lib/incremental-cache/tags-manifest.external');
+
+const MAX_SIZE = 50 * 1024 * 1024; // 50 MB (same as Next.js default)
+
+const memoryCache = new LRUCache(MAX_SIZE, (entry) => entry.size);
+const pendingSets = new Map();
+const debug = process.env.NEXT_PRIVATE_DEBUG_CACHE
+  ? console.debug.bind(console, 'SWRCacheHandler:')
+  : undefined;
+
+/** @type {import('next/dist/server/lib/cache-handlers/types').CacheHandler} */
+module.exports = {
+  async get(cacheKey) {
+    const pendingPromise = pendingSets.get(cacheKey);
+    if (pendingPromise) {
+      debug?.('get', cacheKey, 'pending');
+      await pendingPromise;
+    }
+
+    const privateEntry = memoryCache.get(cacheKey);
+    if (!privateEntry) {
+      debug?.('get', cacheKey, 'not found');
+      return undefined;
+    }
+
+    const entry = privateEntry.entry;
+    const now = performance.timeOrigin + performance.now();
+
+    // Truly expired: past revalidate + stale window — no data to serve
+    if (now > entry.timestamp + entry.expire * 1000) {
+      debug?.('get', cacheKey, 'expired (past expire window)');
+      return undefined;
+    }
+
+    let revalidate = entry.revalidate;
+
+    if (areTagsExpired(entry.tags, entry.timestamp)) {
+      debug?.('get', cacheKey, 'had expired tag');
+      return undefined;
+    }
+
+    if (areTagsStale(entry.tags, entry.timestamp)) {
+      debug?.('get', cacheKey, 'had stale tag');
+      revalidate = -1;
+    }
+
+    // Past revalidate time but within expire window → stale-while-revalidate
+    // Return the cached data (served instantly) with revalidate: -1 to signal
+    // the framework should revalidate in the background.
+    if (now > entry.timestamp + entry.revalidate * 1000) {
+      debug?.('get', cacheKey, 'stale (serving stale-while-revalidate)');
+      revalidate = -1;
+    }
+
+    const [returnStream, newSaved] = entry.value.tee();
+    entry.value = newSaved;
+
+    debug?.('get', cacheKey, 'found', {
+      tags: entry.tags,
+      timestamp: entry.timestamp,
+      expire: entry.expire,
+      revalidate,
+    });
+
+    return {
+      ...entry,
+      revalidate,
+      value: returnStream,
+    };
+  },
+
+  async set(cacheKey, pendingEntry) {
+    debug?.('set', cacheKey, 'start');
+    let resolvePending = () => {};
+    const pendingPromise = new Promise((resolve) => {
+      resolvePending = resolve;
+    });
+    pendingSets.set(cacheKey, pendingPromise);
+    const entry = await pendingEntry;
+    let size = 0;
+    try {
+      const [value, clonedValue] = entry.value.tee();
+      entry.value = value;
+      const reader = clonedValue.getReader();
+      for (let chunk; !(chunk = await reader.read()).done; ) {
+        size += Buffer.from(chunk.value).byteLength;
+      }
+      memoryCache.set(cacheKey, {
+        entry,
+        isErrored: false,
+        errorRetryCount: 0,
+        size,
+      });
+      debug?.('set', cacheKey, 'done');
+    } catch (err) {
+      debug?.('set', cacheKey, 'failed', err);
+    } finally {
+      resolvePending();
+      pendingSets.delete(cacheKey);
+    }
+  },
+
+  async refreshTags() {
+    // Nothing to do for in-memory cache
+  },
+
+  async getExpiration(tags) {
+    const expirations = tags.map((tag) => {
+      const entry = tagsManifest.get(tag);
+      if (!entry) return 0;
+      return entry.expired || 0;
+    });
+    const expiration = Math.max(...expirations, 0);
+    debug?.('getExpiration', { tags, expiration });
+    return expiration;
+  },
+
+  async updateTags(tags, durations) {
+    const now = Math.round(performance.timeOrigin + performance.now());
+    debug?.('updateTags', { tags, timestamp: now });
+    for (const tag of tags) {
+      const existingEntry = tagsManifest.get(tag) || {};
+      if (durations) {
+        const updates = { ...existingEntry };
+        updates.stale = now;
+        if (durations.expire !== undefined) {
+          updates.expired = now + durations.expire * 1000;
+        }
+        tagsManifest.set(tag, updates);
+      } else {
+        tagsManifest.set(tag, {
+          ...existingEntry,
+          expired: now,
+        });
+      }
+    }
+  },
+};

--- a/docs/sessions/session-summary-2026-03-25.md
+++ b/docs/sessions/session-summary-2026-03-25.md
@@ -1,0 +1,64 @@
+# Session Summary — 2026-03-25
+
+## Objectives
+
+- Investigate ongoing cache issues (#132, #133) — users still seeing 20-30s cold cache loads
+- Check if Ironside container is running the latest image
+
+## Key Findings
+
+### Root Cause: Default cache handler ignores `stale` parameter
+
+The default Next.js `'use cache'` handler (`next/dist/server/lib/cache-handlers/default.js`) is an in-memory LRU cache that **deliberately ignores the `stale` parameter** in `cacheLife()`. From the source comments:
+
+> "In-memory caches are fragile and should not use stale-while-revalidate semantics... stale entries should be considered expired/missing."
+
+The handler expires entries at `revalidate` (6h) instead of `revalidate + stale` (30h). After 6 hours, it returns `undefined` — a full cache miss — causing synchronous 30+ second data fetches instead of serving stale data while revalidating in background.
+
+### Container Status
+
+- Container running since 2026-03-23 23:29 CDT (36h uptime)
+- Running an older `:latest` image (pre-PR #131), but cache code hasn't changed since PR #128
+- Cache warming logs show all 5 caches warm successfully at startup and daily 6 AM CT
+- No `.next/cache/` directory exists — all caching is in-memory only
+
+### Timeline of Issue #133
+
+- 6 AM March 24: daily cache warm (all 5 succeeded)
+- 12 PM March 24: cache entries expired (6h revalidate)
+- 9:35 PM March 24: user hit dashboard — 30+ second cold miss (9.5h after expiry)
+
+## Changes Made
+
+### New: `cache-handler.js` (custom cache handler)
+
+Created a custom cache handler that properly supports stale-while-revalidate:
+- Uses `entry.expire` (30h) for true expiry instead of `entry.revalidate` (6h)
+- Between 6h and 30h: returns cached data with `revalidate: -1` (signals background revalidation)
+- Same in-memory LRU (50MB) as default — only the expiry logic changes
+- Configured via `cacheHandlers.default` in `next.config.ts`
+
+### Modified: `next.config.ts`
+
+Added `cacheHandlers.default: require.resolve('./cache-handler.js')` to override the default handler.
+
+### Modified: `CLAUDE.md`
+
+Added "Custom Cache Handler" section under Caching & PPR documenting the issue and fix.
+
+### Modified: `docs/status.md`, session summary
+
+Updated with this session's work.
+
+## Issues Addressed
+
+- #132 — 20+ second contact search load (same root cause)
+- #133 — No cold cache / 30+ second dashboard load
+
+## Files Changed
+
+- **Created**: `cache-handler.js`
+- **Modified**: `next.config.ts`, `CLAUDE.md`, `docs/status.md`
+- **Created**: `docs/sessions/session-summary-2026-03-25.md`
+
+## Status: ⚠️ IN PROGRESS — awaiting branch/PR/deploy

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,14 +2,15 @@
 
 Quick-reference snapshot of current project state. Read this first at session start. For full details on any item, see the relevant session summary in `docs/sessions/`.
 
-**Last updated**: 2026-03-23
+**Last updated**: 2026-03-25
 
 ## Recently Completed
 
 | Date | Work | Issues | PR |
 |------|------|--------|---|
+| 2026-03-25 | **Custom cache handler for stale-while-revalidate**: Default Next.js in-memory handler ignores `stale` param entirely — expires at `revalidate` (6h) instead of `revalidate + stale` (30h). Created `cache-handler.js` with proper SWR support via `cacheHandlers.default` config. | #132, #133 | TBD |
 | 2026-03-23 | **Use nickname on contact logs + timezone fix**: Session name uses MP Contact Nickname; contact log dates now correctly convert to Central Time in the service layer (was using server-local/UTC). Fixed ambiguous `Contact_ID` column in login query. | #129 | #130 |
-| 2026-03-23 | **Fix cache stale-while-revalidate**: Changed `revalidateTag({expire:0})` → `updateTag()` so dashboard and contact cache refreshes serve stale data instantly instead of causing 20-30s cold misses. | #124, #125, #127 | TBD |
+| 2026-03-23 | **Fix cache stale-while-revalidate**: Changed `revalidateTag({expire:0})` → `updateTag()` so dashboard and contact cache refreshes serve stale data instantly instead of causing 20-30s cold misses. | #124, #125, #127 | #128 |
 | 2026-03-23 | **Contact card: age/grade badges & household positions**: Violet badges for minor children's age/grade groups; household position labels under each member. | — | #126 |
 | 2026-03-18 | **Auto contact logging**: Clicking email/phone/text/directions or copying email/phone/address on contact card auto-creates a Contact Log entry. | #121 | #120 |
 | 2026-03-18 | **CI: npm audit step** + **Dependabot security alerts** enabled. Added `npm audit --audit-level=high` to Docker build workflow. | — | — |

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,13 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   output: "standalone", // Required for Docker deployment
   cacheComponents: true, // Enables Cache Components (PPR + 'use cache' directive)
+  cacheHandlers: {
+    // Custom handler that properly supports stale-while-revalidate.
+    // The default in-memory handler ignores cacheLife({ stale }) and expires
+    // entries at revalidate time (6h), causing cold cache misses. This handler
+    // serves stale data instantly while revalidating in the background.
+    default: require.resolve('./cache-handler.js'),
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary

- The default Next.js in-memory cache handler **ignores `cacheLife({ stale })` entirely** — it expires entries at `revalidate` time (6h) and returns `undefined` (a full cache miss), causing 30+ second cold fetches every 6 hours
- Created `cache-handler.js` that uses `entry.expire` (revalidate + stale = 30h) as the true expiry, returning stale data with `revalidate: -1` between 6h–30h so the framework serves stale data instantly while revalidating in the background
- Configured via `cacheHandlers.default` in `next.config.ts`; verified the handler is included in the standalone build output

## Root Cause

From `next/dist/server/lib/cache-handlers/default.js`:

> "In-memory caches are fragile and should not use stale-while-revalidate semantics... stale entries should be considered expired/missing."

The default handler checks `entry.timestamp + entry.revalidate * 1000` and returns `undefined` when expired — never consulting `entry.expire` (which includes the stale window). Our custom handler fixes this single check.

## Timeline (Issue #133)

- 6:00 AM: daily cache warm (all 5 caches, 3:04s)
- 12:00 PM: entries expire (6h revalidate) — **cache gone**
- 9:35 PM: user hits dashboard → 30+ second cold fetch

With this fix: entries remain servable until 12:00 PM next day (30h), served instantly as stale with background revalidation.

Fixes #132, Fixes #133

## Security Review
- **Files reviewed**: 5 files (cache-handler.js, next.config.ts, CLAUDE.md, docs/status.md, session summary)
- **Issues found**: None
- **Checklist**: All critical/high items pass — no user input, no filters, no auth, no PII in changed files
- **Notes**: cache-handler.js uses only Next.js internal APIs (LRU cache, tags manifest)

## Test plan
- [ ] Build succeeds with `npm run build` (verified locally — all pages render as expected)
- [ ] Standalone output includes `cache-handler.js` (verified — `.next/standalone/cache-handler.js` exists)
- [ ] Deploy to Ironside and verify cache warming logs show custom handler
- [ ] After 6+ hours, verify dashboard loads instantly (stale data served) instead of 30s cold fetch
- [ ] Manual refresh (`updateTag`) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)