### PR TITLE
Remove ARM64 from CI build

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -18,9 +18,6 @@ jobs:
       - name: Audit npm dependencies
         run: npm audit --audit-level=high
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -37,7 +34,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: registry.gitlab.com/moodychurch/mp-charts:${{ github.sha }}
           cache-from: type=registry,ref=registry.gitlab.com/moodychurch/mp-charts:buildcache


### PR DESCRIPTION
## Summary
- Remove `linux/arm64` platform from Docker build CI workflow — container runs on x86 only
- Remove the QEMU setup step (only needed for cross-architecture emulation)
- Local ARM64 builds on M-series Macs still work via native `docker build`

## Security Review
- No new endpoints, auth changes, or data handling
- Change is CI-only (GitHub Actions workflow)
- No secrets or env vars affected

## Test plan
- [ ] Verify CI build completes successfully (faster without ARM64 cross-compile)
- [ ] Confirm pushed image runs on x86 deployment target

https://claude.ai/code/session_016AWF4FqCMAEyNkYt38cibS