### PR TITLE
fix: add onError fallback for MP thumbnail images

### DIFF
--- a/docs/sessions/session-summary-2026-04-09.md
+++ b/docs/sessions/session-summary-2026-04-09.md
@@ -3,6 +3,8 @@
 ## Objectives
 
 - Add sort options (by name, most/least milestones completed) to journey and compliance processing pages
+- Investigate broken MP thumbnail images on compliance volunteer cards
+- Add graceful fallback for image load failures
 
 ## Work Completed
 
@@ -23,9 +25,22 @@ Added a sort dropdown to journey tools and compliance tools pages. Users can now
 - `src/components/journey-processing/journey-processing.tsx` — sort state + UI in both layouts
 - `src/components/compliance-processing/compliance-processing.tsx` — same changes for consistency
 
+### Fix: Thumbnail image onError fallback (PR #157) — COMPLETED
+- **Investigation**: Confirmed no recent PRs touched image loading code. The MP files endpoint (`/files/{uniqueFileId}?$thumbnail=true`) doesn't require auth. Root cause likely transient MP API issue or device cache.
+- **Fix**: Added `onError` handlers to all 6 image-rendering locations. When an image fails to load, the component now falls back to showing initials instead of a broken image icon.
+- **Files modified**:
+  - `src/components/processing/person-avatar.tsx` — shared avatar component (compliance, journey, modals)
+  - `src/components/processing/detail-modal-photo-upload.tsx` — detail modal photo with upload
+  - `src/components/layout/header.tsx` — user avatar in header
+  - `src/components/contact-lookup/contact-lookup-results.tsx` — contact search results
+  - `src/components/contact-lookup-details/contact-lookup-details.tsx` — household member images
+  - `src/components/manage-members/member-card.tsx` — member management cards
+
 ## Decisions
 
 - Client-side sorting (not server-side) since all participant data is already loaded
 - Sort applies after search filtering, so search + sort work together
 - Applied to both journey and compliance tools per ui-standards rule about keeping them in sync
 - Last name used as tiebreaker for milestone-based sorts
+- Used `useState(false)` for single-image components, `useState<Set<string>>(new Set())` for list components to track per-image errors
+- No changes to CLAUDE.md or README needed — no new patterns introduced

--- a/docs/status.md
+++ b/docs/status.md
@@ -8,7 +8,8 @@ Quick-reference snapshot of current project state. Read this first at session st
 
 | Date | Work | Issues | PR |
 |------|------|--------|---|
-| 2026-04-09 | **Sort options for journey & compliance tools**: Added sort dropdown (Last Name, Most Completed, Least Completed) to all processing pages. Shared `sortCards()` utility + `ProcessingSortSelect` component. 6 new tests. | — | — |
+| 2026-04-09 | **Fix thumbnail image fallback**: Added `onError` handlers to all 6 image-rendering locations so broken MP thumbnails gracefully fall back to initials instead of broken image icons. | — | #157 |
+| 2026-04-09 | **Sort options for journey & compliance tools**: Added sort dropdown (Last Name, Most Completed, Least Completed) to all processing pages. Shared `sortCards()` utility + `ProcessingSortSelect` component. 6 new tests. | — | #158 |
 | 2026-04-08 | **Test coverage: 88 new tests across 8 files** (236→324 total). Adapted upstream PR #45 for our fork's auth/security patterns. Covers: user-context, session-context, user-menu sign-out, contact-lookup scoring/sorting, contact-logs CRUD actions, contactService with sanitization, contactLogService with Central Time date conversion, MinistryPlatformProvider delegation. | — | #156 |
 | 2026-04-08 | **Upstream sync through PR #55**: Incorporated MP data safety write-confirmation rule into `.claude/rules/security.md`. Updated sync log. | — | — |
 

--- a/src/components/contact-lookup-details/contact-lookup-details.tsx
+++ b/src/components/contact-lookup-details/contact-lookup-details.tsx
@@ -117,6 +117,7 @@ export const ContactLookupDetails: React.FC<ContactLookupDetailsProps> = ({
   const [currentUserId, setCurrentUserId] = useState<number | null>(null);
   const [badges, setBadges] = useState<ContactBadges | null>(null);
   const [familyMembers, setFamilyMembers] = useState<HouseholdMember[]>([]);
+  const [imgErrors, setImgErrors] = useState<Set<string>>(new Set());
   const [familyOpen, setFamilyOpen] = useState(true);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -612,13 +613,14 @@ export const ContactLookupDetails: React.FC<ContactLookupDetailsProps> = ({
                       className="flex flex-col items-center gap-2 rounded-lg border p-3 hover:bg-gray-50 transition-colors"
                     >
                       <div className="h-12 w-12 rounded-full overflow-hidden relative flex-shrink-0">
-                        {member.Image_GUID && mpFileUrl ? (
+                        {member.Image_GUID && mpFileUrl && !imgErrors.has(member.Image_GUID) ? (
                           <Image
                             src={getImageUrl(member.Image_GUID)}
                             alt={`${memberDisplayName} ${member.Last_Name}`}
                             fill
                             className="object-cover"
                             unoptimized
+                            onError={() => setImgErrors(prev => new Set(prev).add(member.Image_GUID!))}
                           />
                         ) : (
                           <div className="w-full h-full bg-gray-300 rounded-full flex items-center justify-center text-gray-600 text-sm font-medium">

--- a/src/components/contact-lookup/contact-lookup-results.tsx
+++ b/src/components/contact-lookup/contact-lookup-results.tsx
@@ -25,6 +25,7 @@ export const ContactLookupResults: React.FC<ContactLookupResultsProps> = ({
   const router = useRouter();
   const { mpFileUrl } = useRuntimeConfig();
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const [imgErrors, setImgErrors] = useState<Set<string>>(new Set());
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
 
@@ -114,7 +115,7 @@ export const ContactLookupResults: React.FC<ContactLookupResultsProps> = ({
           >
             <div className="flex items-center space-x-3">
               <div className="w-10 h-10 rounded-full flex-shrink-0 overflow-hidden relative">
-                {contact.Image_GUID && mpFileUrl ? (
+                {contact.Image_GUID && mpFileUrl && !imgErrors.has(contact.Image_GUID) ? (
                   <Image
                     src={getImageUrl(contact.Image_GUID)}
                     alt={`${getDisplayName(
@@ -124,6 +125,7 @@ export const ContactLookupResults: React.FC<ContactLookupResultsProps> = ({
                     fill
                     className="object-cover"
                     unoptimized
+                    onError={() => setImgErrors(prev => new Set(prev).add(contact.Image_GUID!))}
                   />
                 ) : (
                   <div className="w-full h-full bg-gray-300 rounded-full flex items-center justify-center text-gray-600 text-sm font-medium">

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -10,6 +10,7 @@ import { useAppSession, useUser, useRuntimeConfig } from "@/contexts";
 
 export function Header() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [imgError, setImgError] = useState(false);
   const { userProfile, isLoading } = useUser();
   const session = useAppSession();
   const { mpFileUrl, appName } = useRuntimeConfig();
@@ -47,7 +48,7 @@ export function Header() {
                         "User menu"
                   }
                 >
-                  {userProfile?.Image_GUID && mpFileUrl ? (
+                  {userProfile?.Image_GUID && mpFileUrl && !imgError ? (
                     <Image
                       src={`${mpFileUrl}/${userProfile.Image_GUID}?$thumbnail=true`}
                       alt={
@@ -59,6 +60,7 @@ export function Header() {
                       height={32}
                       className="rounded-full object-cover border-2 border-white"
                       unoptimized
+                      onError={() => setImgError(true)}
                     />
                   ) : (
                     <UserCircleIcon className="h-8 w-8 text-white" />

--- a/src/components/manage-members/member-card.tsx
+++ b/src/components/manage-members/member-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Image from "next/image";
 import { Card, CardContent } from "@/components/ui/card";
 import { getDisplayName, getInitials, getImageUrl, formatDate } from "@/lib/processing-utils";
@@ -13,6 +14,7 @@ interface MemberCardProps {
 }
 
 export function MemberCardComponent({ member, mpFileUrl, onClick }: MemberCardProps) {
+  const [imgError, setImgError] = useState(false);
   const displayName = getDisplayName(member.firstName, member.nickname);
   const fullName = `${displayName} ${member.lastName}`;
   const showNickname = member.nickname && member.nickname !== member.firstName;
@@ -25,13 +27,14 @@ export function MemberCardComponent({ member, mpFileUrl, onClick }: MemberCardPr
       <CardContent className="flex flex-col items-center gap-2 p-4 flex-1">
         {/* Avatar */}
         <div className="w-16 h-16 rounded-full overflow-hidden relative flex-shrink-0">
-          {member.fileUniqueId && mpFileUrl ? (
+          {member.fileUniqueId && mpFileUrl && !imgError ? (
             <Image
               src={getImageUrl(mpFileUrl, member.fileUniqueId)}
               alt={fullName}
               fill
               className="object-cover"
               unoptimized
+              onError={() => setImgError(true)}
             />
           ) : (
             <div className="w-full h-full bg-gray-300 rounded-full flex items-center justify-center font-medium text-gray-600">

--- a/src/components/processing/detail-modal-photo-upload.tsx
+++ b/src/components/processing/detail-modal-photo-upload.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import Image from "next/image";
 import { getDisplayName, getInitials, getImageUrl } from "@/lib/processing-utils";
 
@@ -27,6 +27,7 @@ export function DetailModalPhotoUpload({
   photoInputRef,
   className,
 }: DetailModalPhotoUploadProps) {
+  const [imgError, setImgError] = useState(false);
   const displayName = getDisplayName(firstName, nickname);
 
   return (
@@ -35,7 +36,7 @@ export function DetailModalPhotoUpload({
       onClick={() => photoInputRef.current?.click()}
       title={uploading ? "Uploading..." : "Upload photo"}
     >
-      {imageGuid && mpFileUrl ? (
+      {imageGuid && mpFileUrl && !imgError ? (
         <>
           <Image
             src={getImageUrl(mpFileUrl, imageGuid)}
@@ -43,6 +44,7 @@ export function DetailModalPhotoUpload({
             fill
             className="object-cover"
             unoptimized
+            onError={() => setImgError(true)}
           />
           {uploading ? (
             <div className="absolute inset-0 bg-black/40 rounded-full flex items-center justify-center">

--- a/src/components/processing/person-avatar.tsx
+++ b/src/components/processing/person-avatar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Image from "next/image";
 import { getDisplayName, getInitials, getImageUrl } from "@/lib/processing-utils";
 
@@ -21,19 +22,21 @@ export function PersonAvatar({
   lastName,
   size = "md",
 }: PersonAvatarProps) {
+  const [imgError, setImgError] = useState(false);
   const displayName = getDisplayName(firstName, nickname);
   const sizeClass = size === "sm" ? "w-14 h-14" : "w-16 h-16";
   const textClass = size === "sm" ? "text-lg" : "text-lg";
 
   return (
     <div className={`${sizeClass} rounded-full overflow-hidden relative flex-shrink-0`}>
-      {imageGuid && mpFileUrl ? (
+      {imageGuid && mpFileUrl && !imgError ? (
         <Image
           src={getImageUrl(mpFileUrl, imageGuid)}
           alt={`${displayName} ${lastName}`}
           fill
           className="object-cover"
           unoptimized
+          onError={() => setImgError(true)}
         />
       ) : (
         <div className={`w-full h-full bg-gray-300 rounded-full flex items-center justify-center text-gray-600 ${textClass} font-medium`}>


### PR DESCRIPTION
## Summary
- Adds `onError` handlers to all 6 image-rendering locations so broken MP thumbnail images gracefully fall back to initials instead of showing broken image icons
- Affected components: `PersonAvatar`, `DetailModalPhotoUpload`, `Header`, `ContactLookupResults`, `ContactLookupDetails` (household members), `MemberCard`
- No root cause found in recent code changes — the MP files endpoint doesn't require auth and no recent PRs touched image loading. Most likely a transient MP API issue or device cache, but the app should handle failures gracefully regardless.

## Security Review
- No filter parameters, file uploads, redirects, or server actions modified
- Changes are client-side only (`onError` callbacks on `<Image>` components)

## Test plan
- [ ] Verify compliance volunteer cards show initials (not broken icons) when MP file API is unreachable
- [ ] Verify header user avatar falls back to `UserCircleIcon` on image load failure
- [ ] Verify contact lookup results and detail pages fall back to initials
- [ ] Verify member cards fall back to initials
- [ ] Verify images still load normally when MP file API is available
- [ ] Hard refresh on device to rule out browser cache as original cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)