### PR TITLE
Add sort options to journey and compliance processing pages

### DIFF
--- a/docs/sessions/session-summary-2026-04-09.md
+++ b/docs/sessions/session-summary-2026-04-09.md
@@ -1,0 +1,31 @@
+# Session Summary — 2026-04-09
+
+## Objectives
+
+- Add sort options (by name, most/least milestones completed) to journey and compliance processing pages
+
+## Work Completed
+
+### Sort options for processing pages — COMPLETED
+
+Added a sort dropdown to journey tools and compliance tools pages. Users can now sort participant cards by:
+- **Last Name (A–Z)** — existing default behavior
+- **Most Completed** — highest milestone count first
+- **Least Completed** — lowest milestone count first
+
+**Files created:**
+- `src/components/processing/processing-sort-select.tsx` — Sort dropdown component
+- `src/lib/processing-utils-sort.test.ts` — 6 tests for sort utility
+
+**Files modified:**
+- `src/lib/processing-utils.ts` — `ProcessingSortOption` type, `SORT_OPTIONS`, `sortCards()` utility
+- `src/components/processing/index.ts` — barrel export for `ProcessingSortSelect`
+- `src/components/journey-processing/journey-processing.tsx` — sort state + UI in both layouts
+- `src/components/compliance-processing/compliance-processing.tsx` — same changes for consistency
+
+## Decisions
+
+- Client-side sorting (not server-side) since all participant data is already loaded
+- Sort applies after search filtering, so search + sort work together
+- Applied to both journey and compliance tools per ui-standards rule about keeping them in sync
+- Last name used as tiebreaker for milestone-based sorts

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,16 +2,15 @@
 
 Quick-reference snapshot of current project state. Read this first at session start. For full details on any item, see the relevant session summary in `docs/sessions/`.
 
-**Last updated**: 2026-04-08
+**Last updated**: 2026-04-09
 
 ## Recently Completed
 
 | Date | Work | Issues | PR |
 |------|------|--------|---|
+| 2026-04-09 | **Sort options for journey & compliance tools**: Added sort dropdown (Last Name, Most Completed, Least Completed) to all processing pages. Shared `sortCards()` utility + `ProcessingSortSelect` component. 6 new tests. | — | — |
 | 2026-04-08 | **Test coverage: 88 new tests across 8 files** (236→324 total). Adapted upstream PR #45 for our fork's auth/security patterns. Covers: user-context, session-context, user-menu sign-out, contact-lookup scoring/sorting, contact-logs CRUD actions, contactService with sanitization, contactLogService with Central Time date conversion, MinistryPlatformProvider delegation. | — | #156 |
 | 2026-04-08 | **Upstream sync through PR #55**: Incorporated MP data safety write-confirmation rule into `.claude/rules/security.md`. Updated sync log. | — | — |
-| 2026-04-07 | **CLAUDE.md restructure & CI security lint**: Extracted 5 rule files into `.claude/rules/` (723→191 lines). Added `security-lint` CI job that greps for unsanitized `.join()` in filter parameters. | — | — |
-| 2026-04-07 | **Fix filter injection: sanitize ID arrays**: 5 instances of unsanitized `.join(",")` in filter parameters replaced with `sanitizeIds()`. Merged Dependabot vite 8.0.0→8.0.5 (path traversal fix). | — | #153, #154 |
 
 ## Planned
 

--- a/src/components/compliance-processing/compliance-processing.tsx
+++ b/src/components/compliance-processing/compliance-processing.tsx
@@ -3,11 +3,11 @@
 import React, { useEffect, useState, useCallback, useMemo } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ComplianceCard as ComplianceCardData } from "@/lib/dto";
-import { ProcessingGrid, ProcessingSearchBar } from "@/components/processing";
+import { ProcessingGrid, ProcessingSearchBar, ProcessingSortSelect } from "@/components/processing";
 import { ComplianceCard } from "./compliance-card";
 import { ComplianceDetailModal } from "./compliance-detail-modal";
 import { getComplianceParticipants, getPausedComplianceParticipants } from "./actions";
-import { searchByName } from "@/lib/processing-utils";
+import { searchByName, sortCards, type ProcessingSortOption } from "@/lib/processing-utils";
 import type { ComplianceToolConfig } from "@/lib/compliance-tools-config-types";
 
 interface ComplianceProcessingProps {
@@ -22,6 +22,7 @@ export function ComplianceProcessing({ slug, config, initialApplicantId }: Compl
   const [currentParticipants, setCurrentParticipants] = useState<ComplianceCardData[]>([]);
   const [pausedParticipants, setPausedParticipants] = useState<ComplianceCardData[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
+  const [sortOption, setSortOption] = useState<ProcessingSortOption>("name");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedParticipant, setSelectedParticipant] = useState<ComplianceCardData | null>(null);
@@ -93,13 +94,13 @@ export function ComplianceProcessing({ slug, config, initialApplicantId }: Compl
   };
 
   const filteredCurrent = useMemo(
-    () => searchByName(currentParticipants, searchQuery),
-    [currentParticipants, searchQuery]
+    () => sortCards(searchByName(currentParticipants, searchQuery), sortOption),
+    [currentParticipants, searchQuery, sortOption]
   );
 
   const filteredPaused = useMemo(
-    () => searchByName(pausedParticipants, searchQuery),
-    [pausedParticipants, searchQuery]
+    () => sortCards(searchByName(pausedParticipants, searchQuery), sortOption),
+    [pausedParticipants, searchQuery, sortOption]
   );
 
   // When pause is not supported, render a single grid (no tabs)
@@ -111,7 +112,10 @@ export function ComplianceProcessing({ slug, config, initialApplicantId }: Compl
           <p className="text-muted-foreground">{config.description}</p>
         </div>
 
-        <ProcessingSearchBar value={searchQuery} onChange={setSearchQuery} />
+        <div className="flex flex-col sm:flex-row gap-3">
+          <ProcessingSearchBar value={searchQuery} onChange={setSearchQuery} />
+          <ProcessingSortSelect value={sortOption} onChange={setSortOption} />
+        </div>
 
         <ProcessingGrid
           items={filteredCurrent}
@@ -167,7 +171,10 @@ export function ComplianceProcessing({ slug, config, initialApplicantId }: Compl
               )}
             </TabsTrigger>
           </TabsList>
-          <ProcessingSearchBar value={searchQuery} onChange={setSearchQuery} />
+          <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
+            <ProcessingSearchBar value={searchQuery} onChange={setSearchQuery} />
+            <ProcessingSortSelect value={sortOption} onChange={setSortOption} />
+          </div>
         </div>
 
         <TabsContent value="current">

--- a/src/components/compliance-processing/compliance-processing.tsx
+++ b/src/components/compliance-processing/compliance-processing.tsx
@@ -112,7 +112,7 @@ export function ComplianceProcessing({ slug, config, initialApplicantId }: Compl
           <p className="text-muted-foreground">{config.description}</p>
         </div>
 
-        <div className="flex flex-col sm:flex-row gap-3">
+        <div className="flex flex-col sm:flex-row sm:justify-end gap-3">
           <ProcessingSearchBar value={searchQuery} onChange={setSearchQuery} />
           <ProcessingSortSelect value={sortOption} onChange={setSortOption} />
         </div>
@@ -171,7 +171,7 @@ export function ComplianceProcessing({ slug, config, initialApplicantId }: Compl
               )}
             </TabsTrigger>
           </TabsList>
-          <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
+          <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-fit">
             <ProcessingSearchBar value={searchQuery} onChange={setSearchQuery} />
             <ProcessingSortSelect value={sortOption} onChange={setSortOption} />
           </div>

--- a/src/components/journey-processing/journey-processing.tsx
+++ b/src/components/journey-processing/journey-processing.tsx
@@ -155,7 +155,7 @@ export function JourneyProcessing({ slug, config, initialApplicantId }: JourneyP
           <p className="text-muted-foreground">{config.description}</p>
         </div>
 
-        <div className="flex flex-col sm:flex-row gap-3">
+        <div className="flex flex-col sm:flex-row sm:justify-end gap-3">
           <ProcessingSearchBar value={searchQuery} onChange={setSearchQuery} />
           <ProcessingSortSelect value={sortOption} onChange={setSortOption} />
         </div>
@@ -228,7 +228,7 @@ export function JourneyProcessing({ slug, config, initialApplicantId }: JourneyP
               </>
             )}
           </TabsList>
-          <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
+          <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-fit">
             <ProcessingSearchBar value={searchQuery} onChange={setSearchQuery} />
             <ProcessingSortSelect value={sortOption} onChange={setSortOption} />
           </div>

--- a/src/components/journey-processing/journey-processing.tsx
+++ b/src/components/journey-processing/journey-processing.tsx
@@ -3,11 +3,11 @@
 import React, { useEffect, useState, useCallback, useMemo } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { JourneyCard as JourneyCardData } from "@/lib/dto";
-import { ProcessingGrid, ProcessingSearchBar } from "@/components/processing";
+import { ProcessingGrid, ProcessingSearchBar, ProcessingSortSelect } from "@/components/processing";
 import { JourneyCard } from "./journey-card";
 import { JourneyDetailModal } from "./journey-detail-modal";
 import { getJourneyParticipants, getCompletedJourneyParticipants, getPausedJourneyParticipants } from "./actions";
-import { searchByName } from "@/lib/processing-utils";
+import { searchByName, sortCards, type ProcessingSortOption } from "@/lib/processing-utils";
 import type { JourneyToolConfig } from "@/lib/journey-tools-config-types";
 
 interface JourneyProcessingProps {
@@ -26,6 +26,7 @@ export function JourneyProcessing({ slug, config, initialApplicantId }: JourneyP
   const [completedParticipants, setCompletedParticipants] = useState<JourneyCardData[]>([]);
   const [pausedParticipants, setPausedParticipants] = useState<JourneyCardData[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
+  const [sortOption, setSortOption] = useState<ProcessingSortOption>("name");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedParticipant, setSelectedParticipant] = useState<JourneyCardData | null>(null);
@@ -116,18 +117,18 @@ export function JourneyProcessing({ slug, config, initialApplicantId }: JourneyP
   };
 
   const filteredCurrent = useMemo(
-    () => searchByName(currentParticipants, searchQuery),
-    [currentParticipants, searchQuery]
+    () => sortCards(searchByName(currentParticipants, searchQuery), sortOption),
+    [currentParticipants, searchQuery, sortOption]
   );
 
   const filteredCompleted = useMemo(
-    () => searchByName(completedParticipants, searchQuery),
-    [completedParticipants, searchQuery]
+    () => sortCards(searchByName(completedParticipants, searchQuery), sortOption),
+    [completedParticipants, searchQuery, sortOption]
   );
 
   const filteredPaused = useMemo(
-    () => searchByName(pausedParticipants, searchQuery),
-    [pausedParticipants, searchQuery]
+    () => sortCards(searchByName(pausedParticipants, searchQuery), sortOption),
+    [pausedParticipants, searchQuery, sortOption]
   );
 
   const keyExtractor = (a: JourneyCardData) => a.info.Group_Participant_ID ?? a.info.Participant_ID;
@@ -154,7 +155,10 @@ export function JourneyProcessing({ slug, config, initialApplicantId }: JourneyP
           <p className="text-muted-foreground">{config.description}</p>
         </div>
 
-        <ProcessingSearchBar value={searchQuery} onChange={setSearchQuery} />
+        <div className="flex flex-col sm:flex-row gap-3">
+          <ProcessingSearchBar value={searchQuery} onChange={setSearchQuery} />
+          <ProcessingSortSelect value={sortOption} onChange={setSortOption} />
+        </div>
 
         <ProcessingGrid
           items={filteredCurrent}
@@ -224,7 +228,10 @@ export function JourneyProcessing({ slug, config, initialApplicantId }: JourneyP
               </>
             )}
           </TabsList>
-          <ProcessingSearchBar value={searchQuery} onChange={setSearchQuery} />
+          <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
+            <ProcessingSearchBar value={searchQuery} onChange={setSearchQuery} />
+            <ProcessingSortSelect value={sortOption} onChange={setSortOption} />
+          </div>
         </div>
 
         {isMilestoneMode ? (

--- a/src/components/processing/index.ts
+++ b/src/components/processing/index.ts
@@ -7,3 +7,4 @@ export { MilestoneExpandedView } from './milestone-expanded-view';
 export { MilestoneEditForm } from './milestone-edit-form';
 export { QuickActionsPanel, QuickActionButton } from './quick-actions-panel';
 export { ProcessingSearchBar } from './processing-search-bar';
+export { ProcessingSortSelect } from './processing-sort-select';

--- a/src/components/processing/processing-sort-select.tsx
+++ b/src/components/processing/processing-sort-select.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import React from "react";
+import { SORT_OPTIONS, type ProcessingSortOption } from "@/lib/processing-utils";
+
+interface ProcessingSortSelectProps {
+  value: ProcessingSortOption;
+  onChange: (value: ProcessingSortOption) => void;
+}
+
+export function ProcessingSortSelect({ value, onChange }: ProcessingSortSelectProps) {
+  return (
+    <div className="relative w-full sm:w-auto">
+      <svg
+        className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M3 7.5L7.5 3m0 0L12 7.5M7.5 3v13.5m13.5-3L16.5 18m0 0L12 13.5m4.5 4.5V4.5"
+        />
+      </svg>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value as ProcessingSortOption)}
+        className="flex h-9 w-full sm:w-auto rounded-md border border-input bg-transparent pl-8 pr-8 py-1 text-base sm:text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring appearance-none cursor-pointer"
+      >
+        {SORT_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+      <svg
+        className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+      </svg>
+    </div>
+  );
+}

--- a/src/components/processing/processing-sort-select.tsx
+++ b/src/components/processing/processing-sort-select.tsx
@@ -10,7 +10,7 @@ interface ProcessingSortSelectProps {
 
 export function ProcessingSortSelect({ value, onChange }: ProcessingSortSelectProps) {
   return (
-    <div className="relative w-full sm:w-auto">
+    <div className="relative w-full sm:w-fit">
       <svg
         className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none"
         fill="none"
@@ -27,7 +27,7 @@ export function ProcessingSortSelect({ value, onChange }: ProcessingSortSelectPr
       <select
         value={value}
         onChange={(e) => onChange(e.target.value as ProcessingSortOption)}
-        className="flex h-9 w-full sm:w-auto rounded-md border border-input bg-transparent pl-8 pr-8 py-1 text-base sm:text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring appearance-none cursor-pointer"
+        className="flex h-9 w-full sm:w-fit rounded-md border border-input bg-transparent pl-8 pr-3 py-1 text-base sm:text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring cursor-pointer"
       >
         {SORT_OPTIONS.map((opt) => (
           <option key={opt.value} value={opt.value}>
@@ -35,15 +35,6 @@ export function ProcessingSortSelect({ value, onChange }: ProcessingSortSelectPr
           </option>
         ))}
       </select>
-      <svg
-        className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-      >
-        <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-      </svg>
     </div>
   );
 }

--- a/src/lib/processing-utils-sort.test.ts
+++ b/src/lib/processing-utils-sort.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { sortCards, type ProcessingSortOption } from "@/lib/processing-utils";
+import type { BaseCardData, BasePersonInfo } from "@/lib/dto/processing-shared";
+
+function makeCard(
+  lastName: string,
+  firstName: string,
+  completedCount: number,
+  totalCount: number,
+): BaseCardData<BasePersonInfo> {
+  return {
+    info: {
+      Contact_ID: 1,
+      Participant_ID: 1,
+      First_Name: firstName,
+      Nickname: null,
+      Last_Name: lastName,
+      Image_GUID: null,
+      Group_Participant_ID: null,
+      Start_Date: null,
+    },
+    checklist: [],
+    completedCount,
+    totalCount,
+  };
+}
+
+describe("sortCards", () => {
+  const cards = [
+    makeCard("Smith", "John", 3, 5),
+    makeCard("Adams", "Alice", 1, 5),
+    makeCard("Baker", "Bob", 5, 5),
+    makeCard("Adams", "Zara", 2, 5),
+  ];
+
+  it("sorts by last name (A-Z) with first name tiebreaker", () => {
+    const result = sortCards(cards, "name");
+    expect(result.map((c) => c.info.Last_Name)).toEqual([
+      "Adams",
+      "Adams",
+      "Baker",
+      "Smith",
+    ]);
+    expect(result[0].info.First_Name).toBe("Alice");
+    expect(result[1].info.First_Name).toBe("Zara");
+  });
+
+  it("sorts by most completed first with last name tiebreaker", () => {
+    const result = sortCards(cards, "most-completed");
+    expect(result.map((c) => c.completedCount)).toEqual([5, 3, 2, 1]);
+  });
+
+  it("sorts by least completed first with last name tiebreaker", () => {
+    const result = sortCards(cards, "least-completed");
+    expect(result.map((c) => c.completedCount)).toEqual([1, 2, 3, 5]);
+  });
+
+  it("uses last name as tiebreaker for milestone sorts", () => {
+    const tied = [
+      makeCard("Zane", "A", 3, 5),
+      makeCard("Adams", "B", 3, 5),
+    ];
+    const mostResult = sortCards(tied, "most-completed");
+    expect(mostResult.map((c) => c.info.Last_Name)).toEqual(["Adams", "Zane"]);
+
+    const leastResult = sortCards(tied, "least-completed");
+    expect(leastResult.map((c) => c.info.Last_Name)).toEqual([
+      "Adams",
+      "Zane",
+    ]);
+  });
+
+  it("does not mutate the original array", () => {
+    const original = [...cards];
+    sortCards(cards, "most-completed");
+    expect(cards).toEqual(original);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(sortCards([], "name")).toEqual([]);
+  });
+});

--- a/src/lib/processing-utils.ts
+++ b/src/lib/processing-utils.ts
@@ -3,6 +3,48 @@
  * (volunteer, baptism, membership).
  */
 
+import type { BaseCardData, BasePersonInfo } from '@/lib/dto/processing-shared';
+
+/** Available sort options for processing card grids. */
+export type ProcessingSortOption = "name" | "most-completed" | "least-completed";
+
+/** Label/value pairs for sort option dropdowns. */
+export const SORT_OPTIONS: { value: ProcessingSortOption; label: string }[] = [
+  { value: "name", label: "Last Name (A\u2013Z)" },
+  { value: "most-completed", label: "Most Completed" },
+  { value: "least-completed", label: "Least Completed" },
+];
+
+/** Sort processing cards by the selected sort option. Returns a new sorted array. */
+export function sortCards<T extends BaseCardData<BasePersonInfo>>(
+  items: T[],
+  sort: ProcessingSortOption,
+): T[] {
+  const sorted = [...items];
+  switch (sort) {
+    case "name":
+      sorted.sort((a, b) => {
+        const lastCmp = a.info.Last_Name.localeCompare(b.info.Last_Name);
+        if (lastCmp !== 0) return lastCmp;
+        return a.info.First_Name.localeCompare(b.info.First_Name);
+      });
+      break;
+    case "most-completed":
+      sorted.sort((a, b) => {
+        if (b.completedCount !== a.completedCount) return b.completedCount - a.completedCount;
+        return a.info.Last_Name.localeCompare(b.info.Last_Name);
+      });
+      break;
+    case "least-completed":
+      sorted.sort((a, b) => {
+        if (a.completedCount !== b.completedCount) return a.completedCount - b.completedCount;
+        return a.info.Last_Name.localeCompare(b.info.Last_Name);
+      });
+      break;
+  }
+  return sorted;
+}
+
 /** Display name: prefer nickname if present, else first name. */
 export function getDisplayName(firstName: string, nickname: string | null): string {
   return nickname && nickname.trim() ? nickname : firstName;


### PR DESCRIPTION
## Summary
- Adds a sort dropdown to all journey and compliance processing pages with three options: **Last Name (A–Z)**, **Most Completed**, and **Least Completed**
- New shared `sortCards()` utility in `processing-utils.ts` and `ProcessingSortSelect` component in `src/components/processing/`
- Applied to both journey and compliance tools for consistency per ui-standards rule

## Test Plan
- [ ] Navigate to a **journey tool page** (milestone mode) — verify sort dropdown appears next to search bar
- [ ] Select **"Most Completed"** — verify participants reorder with highest milestone count first
- [ ] Select **"Least Completed"** — verify participants reorder with lowest milestone count first
- [ ] Select **"Last Name (A–Z)"** — verify participants return to alphabetical order
- [ ] Switch between **In Progress** and **Completed** tabs — verify sort persists across tabs
- [ ] Type a **search query** while a sort is active — verify search filters and sort applies to results
- [ ] Navigate to a **compliance tool page** — verify sort dropdown appears and works identically
- [ ] Test on **mobile** (375px width) — verify sort dropdown stacks correctly below search bar
- [ ] Verify sort dropdown has no effect on the detail modal opening (click a card after sorting)

## Security Review
- **Files reviewed**: 8 files
- **Issues found**: None
- **Checklist**: All critical/high items pass
- **Notes**: All changes are client-side (React state, `useMemo`, `<select>` element). No server actions, filter parameters, file uploads, or redirects were added or modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)