### PR TITLE
ci: build all branches and tag :dev for testing

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -3,10 +3,7 @@ name: Build, Scan, and Push Docker Image
 on:
   push:
     branches:
-      - main
-  pull_request:
-    branches:
-      - main
+      - '**'
 
 jobs:
   security-lint:
@@ -78,8 +75,16 @@ jobs:
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
 
-      - name: Push `latest` tag
-        # Only push the 'latest' tag when the workflow is triggered by a push to the main branch
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      - name: Push `dev` tag
+        # Every successful build (any branch) becomes the testing image. Pull
+        # `:dev` on the docker host to test branch builds before merging the PR.
         run: |
-          docker buildx imagetools create registry.gitlab.com/moodychurch/mp-charts:${{ github.sha }} --tag registry.gitlab.com/moodychurch/mp-charts:latest
+          docker buildx imagetools create registry.gitlab.com/moodychurch/mp-charts:${{ github.sha }} --tag registry.gitlab.com/moodychurch/mp-charts:dev
+
+      - name: Push `latest` and `main` tags
+        # Stable tags — only updated by main pushes (i.e. merged PRs).
+        if: github.ref == 'refs/heads/main'
+        run: |
+          docker buildx imagetools create registry.gitlab.com/moodychurch/mp-charts:${{ github.sha }} \
+            --tag registry.gitlab.com/moodychurch/mp-charts:latest \
+            --tag registry.gitlab.com/moodychurch/mp-charts:main

--- a/.gitignore
+++ b/.gitignore
@@ -428,5 +428,7 @@ data/feedback-config.json
 .github\instructions\snyk_rules.instructions.md
 .claude/plans/test-plan-journey-compliance-admin.md
 
-# Deploy command contains infrastructure details (IPs, SSH users, paths)
+# Deploy commands contain infrastructure details (compose paths, container names, SSH host aliases)
 .claude/commands/deploy.md
+.claude/commands/deploy-dev.md
+.claude/commands/deploy-main.md


### PR DESCRIPTION
## Summary

- Trigger the Docker build workflow on push to **any branch** (was: `main` only).
- Every successful build also gets the `:dev` tag — pull `:dev` on the docker host to test a feature branch before merging the PR.
- `:latest` and `:main` tags only update on `main` pushes, so they remain stable pointers to the last merged commit.
- Removes the `pull_request` trigger since push now covers all branches; otherwise PRs from same-repo branches would build twice.
- SHA tags are unchanged (still produced on every build).

## Tag matrix after this PR

| Trigger | Tags pushed |
|---|---|
| Push to feature branch | `:<sha>`, `:dev` |
| Push to `main` (merge) | `:<sha>`, `:dev`, `:latest`, `:main` |

## Workflow

1. Push to a feature branch → CI builds, tags `:dev`.
2. On TMC1, `docker pull registry.gitlab.com/moodychurch/mp-charts:dev` and restart the test container to verify.
3. Merge the PR → `:latest` and `:main` update on the main build.

## Security Review

No new attack surface. Trivy CRITICAL/HIGH gating and `npm audit --audit-level=high` still run on every build, including feature branches — so a vulnerable image can't be tagged `:dev`. The `dependabot[bot]` skip is unchanged. The image scan was already running on PRs to main; now it just runs on the push instead.

## Test plan

- [ ] Push to a non-main branch (this PR's branch) — verify CI runs and tags `:<sha>` + `:dev` (not `:latest`/`:main`)
- [ ] After merge to main — verify `:<merge-sha>`, `:dev`, `:latest`, and `:main` all point to the same image
- [ ] Trivy still gates on CRITICAL/HIGH on a non-main push

🤖 Generated with [Claude Code](https://claude.com/claude-code)