### PR TITLE
chore(ci): bump trivy-action v0.35.0 → v0.36.0

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -66,7 +66,7 @@ jobs:
           cache-to: type=registry,ref=registry.gitlab.com/moodychurch/mp-charts:buildcache,mode=max
 
       - name: Scan image
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: 'registry.gitlab.com/moodychurch/mp-charts:${{ github.sha }}'
           format: 'table'

--- a/docs/sessions/session-summary-2026-05-04.md
+++ b/docs/sessions/session-summary-2026-05-04.md
@@ -29,3 +29,11 @@ The journey-tool editor already enforced `programId` always-required (`journey-t
 
 - Pre-existing tsc errors in `authorization.test.ts` and `helper.test.ts` confirmed unrelated to this change (reproduced on `main`).
 - `ComplianceToolConfigSchema` is now `ZodEffects` rather than `ZodObject`; only `.parse()` and `z.array()` consumers exist, so no callsites break.
+
+## Dependency bumps — COMPLETED
+
+- **postcss 8.5.8 → 8.5.10** (PR #166): dependabot fix for GHSA-qx2v-qp2m-jg93 / CVE-2026-41305 (XSS via unescaped `</style>` in stringify output, medium / CVSS 6.1). Transitive dev dep — practical risk low for our build chain, but the bump is trivial. Merged and rolled out to TMC1.
+- **aquasecurity/trivy-action v0.35.0 → v0.36.0** (this PR): clears the Node.js 20 deprecation warning surfaced during the postcss build. v0.36.0 internally pins `actions/cache@v5.0.5`, which runs on Node 24. No behavior change for our scan step.
+
+**Files modified:**
+- `.github/workflows/docker-build-push.yml`

--- a/docs/status.md
+++ b/docs/status.md
@@ -8,6 +8,8 @@ Quick-reference snapshot of current project state. Read this first at session st
 
 | Date | Work | Issues | PR |
 |------|------|--------|---|
+| 2026-05-04 | **CI: bump trivy-action v0.35.0 → v0.36.0**: clears Node.js 20 deprecation warning (v0.36.0 uses `actions/cache@v5.0.5` on Node 24). | — | (pending) |
+| 2026-05-04 | **Security: bump postcss 8.5.8 → 8.5.10** (dependabot): fixes GHSA-qx2v-qp2m-jg93 / CVE-2026-41305 (XSS via unescaped `</style>`, medium). Transitive dev dep. | — | #166 |
 | 2026-05-04 | **Fix: require Program when journey is attached to compliance tool**: Stillson tool was saved with `journeyId` + `journeyMilestones` but `programId: null`, which left the Mark Complete button disabled for journey milestones. Added Zod `.refine()` + editor-side validation so the misconfig can't slip through again. | — | (pending) |
 | 2026-04-09 | **Fix thumbnail image fallback**: Added `onError` handlers to all 6 image-rendering locations so broken MP thumbnails gracefully fall back to initials instead of broken image icons. | — | #157 |
 | 2026-04-09 | **Sort options for journey & compliance tools**: Added sort dropdown (Last Name, Most Completed, Least Completed) to all processing pages. Shared `sortCards()` utility + `ProcessingSortSelect` component. 6 new tests. | — | #158 |


### PR DESCRIPTION
## Summary

- Bumps `aquasecurity/trivy-action` from v0.35.0 to v0.36.0 in `.github/workflows/docker-build-push.yml`.
- Clears the Node.js 20 deprecation warning surfaced on recent CI runs (notice: \"Node.js 20 actions are deprecated... actions/cache@0400d5f...\").
- v0.36.0 internally pins `actions/cache@27d5ce7` (v5.0.5), which runs on Node 24.

## Why

GitHub will force Node 20 actions to Node 24 starting **June 2, 2026**, and remove Node 20 from runners on **September 16, 2026**. This bump gets ahead of the forced migration and silences the build annotation now.

## Security Review

- No application source code touched — only `.github/workflows/docker-build-push.yml`.
- No filter parameters, file uploads, redirects, auth code, or server actions changed.
- Trivy vuln scan step itself is unchanged (same `image-ref`, `severity`, `vuln-type`, `exit-code: '1'`); only the action version it runs under changes.

## Test plan

- [ ] CI `security-lint` ✅
- [ ] CI `build-scan-and-push` ✅ (Trivy still runs against the new image SHA, fails on CRITICAL/HIGH)
- [ ] Build annotations no longer flag Node 20 deprecation