### PR TITLE
feat: contact-lookup Groups section + sectioned compliance cards (#162, #163)

### DIFF
--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -26,6 +26,8 @@ Ideas and enhancements for the MPNext project. This file syncs bidirectionally w
 
 ### Improvements
 - [Serving metrics: reconcile adult-only vs all-ages counts (#110)](#serving-metrics-reconcile-adult-only-vs-all-ages-counts-110)
+- ~~[Card Summaries should have sections (#163)](#card-summaries-should-have-sections-163)~~ ✅
+- ~~[see all groups (#162)](#see-all-groups-162)~~ ✅
 - ~~[Use Nickname Last name on contact logs (#129)](#use-nickname-last-name-on-contact-logs-129)~~ ✅
 - ~~[Auto contact log on action link clicks (#121)](#auto-contact-log-on-action-link-clicks-121)~~ ✅
 - ~~[Add "X" to the top right of the contact card (#116)](#add-x-to-the-top-right-of-the-contact-card-116)~~ ✅
@@ -158,6 +160,12 @@ Extracted `statusBadgeColor` to shared utility (`src/lib/contact-badge-utils.ts`
 
 ### Serving metrics: reconcile adult-only vs all-ages counts ([#110](https://github.com/The-Moody-Church/mp-charts/issues/110))
 The Engagement Overview Venn diagram filters serving/leading to **adults only** (18+ or unknown birthdate), showing ~830. The Grow in Love section's "Serving by Role Type" counts **all ages**, showing ~1,022. The ~192-person gap is minors with active serving/leading roles (e.g., student volunteers). Need to decide: should the Grow in Love charts also filter to adults, or should the Venn diagram include all ages? Or add an "(all ages)" note to the Grow in Love description to make the difference explicit?
+
+### ~~Card Summaries should have sections ([#163](https://github.com/The-Moody-Church/mp-charts/issues/163))~~ ✅ COMPLETED
+Compliance cards now split the checklist into "Requirements" and "Milestones" sections with small uppercase headers, mirroring the section structure already in the detail modal. Tools without journey milestones (e.g., active-teachers-and-volunteers) keep the original single-list layout. Filed from the `/compliance/stillson-residents` page.
+
+### ~~see all groups ([#162](https://github.com/The-Moody-Church/mp-charts/issues/162))~~ ✅ COMPLETED
+Added a "Groups" section to the contact lookup detail page that lists every active Group_Participant for the contact (Group Name, Type, Role, Joined date). The "In a Group" and "Serving" badges are now buttons that toggle the section open and lazy-load the data. Wired through `ContactService.getContactGroupMemberships`, the `getContactGroups` server action, and a new `ContactGroupMembership` DTO.
 
 ### ~~Use Nickname Last name on contact logs ([#129](https://github.com/The-Moody-Church/mp-charts/issues/129))~~ ✅ COMPLETED
 Auto-created contact logs now use the user's MP Contact Nickname (e.g., "Jonny Huff") instead of the formal OIDC given_name (e.g., "Jonathon Huff"). The nickname is fetched from the Contact record during login and stored in the session. Also fixed contact log dates to convert to Central Time in the service layer (was using server-local UTC in Docker).

--- a/docs/sessions/session-summary-2026-05-05.md
+++ b/docs/sessions/session-summary-2026-05-05.md
@@ -1,0 +1,61 @@
+# Session Summary — 2026-05-05
+
+## Objectives
+
+Tackle two open user-feedback issues:
+- **#162** — *see all groups*: clicking the "In a Group" badge on the contact lookup detail page should reveal a list of all groups where the contact is a current member.
+- **#163** — *Card Summaries should have sections*: compliance card summaries (e.g., on `/compliance/stillson-residents`) should split Requirements from Milestones so the difference is visible at a glance.
+
+## Work Completed
+
+### #163 — Compliance card sections (COMPLETED)
+
+The compliance detail modal already separates `requirementItems` from `journeyMilestoneItems`. Mirrored that split on the card itself.
+
+- `src/components/compliance-processing/compliance-card.tsx`: filtered `checklist` into `requirementItems` (`type !== 'journey_milestone'`) and `milestoneItems` (`type === 'journey_milestone'`); render each block under a small uppercase header. Headers only appear when both groups are present, so tools without journey milestones (e.g., `active-teachers-and-volunteers`) keep the original single-list look.
+
+### #162 — Groups section on contact lookup (COMPLETED)
+
+Added an end-to-end path for fetching and displaying current group memberships.
+
+- `src/lib/dto/contacts.ts`: new `ContactGroupMembership` interface (Group_Participant_ID, Group_ID, Group_Name, Group_Type/_ID, Role/Group_Role_ID, Start/End_Date).
+- `src/services/contactService.ts`: new `getContactGroupMemberships(contactId)`. Looks up the Participant_Record(s), then queries `Group_Participants` filtered to currently-active rows on both the Group_Participant and the parent Group. Joins through `Group_ID_Table` (Group_Name, Group_Type via `_Group_Type_ID_Table`) and `Group_Role_ID_Table` (Role_Title) — same double-join syntax already used elsewhere in the file.
+- `src/components/contact-lookup-details/actions.ts`: `getContactGroups` server action (gated by `requireFeatureAccess("contact-lookup")`, swallows errors → `[]`).
+- `src/components/contact-lookup-details/contact-lookup-details.tsx`:
+  - "In a Group" and "Serving" badges are now `<button>`s that toggle a new `Groups` section card open.
+  - Section is between the contact card and the Family section, only shown when `inGroup || serving`.
+  - Lazy-loaded on first expansion; cleared in `fetchContactDetails` so navigation between contacts doesn't show stale data.
+  - Each membership renders as Group Name + (Group Type · Role · Joined date).
+
+### Tests
+
+- `src/services/contactService.test.ts`: two new cases for `getContactGroupMemberships` — empty short-circuit when no participant exists, and the happy path verifying filter contains `Participant_ID IN (…)` and the active-window predicates on both `Group_Participants.[Start_Date]` and `Group_ID_Table.[Start_Date]`.
+- Full suite: `npm run test:run` → 460 / 460 pass.
+- Pre-existing TS errors in unrelated test files (`authorization.test.ts`, `helper.test.ts`, `userService.test.ts`) — not introduced by this change.
+
+## Decisions / Rationale
+
+- **No "View in MP" link in the Groups section**: I don't have a confirmed MP page ID for the Groups page in this deployment. Better to omit than send users to a 404 — easy to add later.
+- **No filter by Group_Type**: the issue asks for "all groups where contact is a current member". I considered filtering out Age/Grade groups (already shown as separate badges) but decided the full canonical list is more useful — the badges remain at-a-glance summaries.
+- **Why the section auto-shows when `serving` is true**: even when `inGroup` is false, a `serving` member by definition has at least one active Group_Participant (the role check is on `Group_Participants`). Letting the Serving badge expand the same list is cheap and consistent.
+- **Tests for the card UI weren't added**: per `.claude/rules/testing.md`, React components don't need unit tests. The compliance-card change is a pure render reshuffle that the existing detail modal already validates structurally.
+
+## Files Changed
+
+**Modified**:
+- `src/components/compliance-processing/compliance-card.tsx`
+- `src/components/contact-lookup-details/contact-lookup-details.tsx`
+- `src/components/contact-lookup-details/actions.ts`
+- `src/services/contactService.ts`
+- `src/services/contactService.test.ts`
+- `src/lib/dto/contacts.ts`
+- `docs/ideas.md`
+- `docs/status.md`
+
+**Created**:
+- `docs/sessions/session-summary-2026-05-05.md` (this file)
+
+## Follow-ups
+
+- If `mptools.moodychurch.org/mp/<id>/<groupId>` is a known MP page, add a "View in MP" link to each Groups section row.
+- Issue #161 (*student leaders*) is still open — surfaced in `status.md` Open Issues for next session.

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,19 +2,16 @@
 
 Quick-reference snapshot of current project state. Read this first at session start. For full details on any item, see the relevant session summary in `docs/sessions/`.
 
-**Last updated**: 2026-05-04
+**Last updated**: 2026-05-05
 
 ## Recently Completed
 
 | Date | Work | Issues | PR |
 |------|------|--------|---|
+| 2026-05-05 | **Contact lookup: Groups section + sectioned compliance cards**: Added a "Groups" section to the contact lookup detail page that lists every active Group_Participant for the contact (clickable via the In a Group / Serving badges, lazy-loaded). Compliance cards now split the checklist into Requirements vs Milestones sections. | #162, #163 | (pending) |
 | 2026-05-04 | **CI: bump trivy-action v0.35.0 → v0.36.0**: clears Node.js 20 deprecation warning (v0.36.0 uses `actions/cache@v5.0.5` on Node 24). | — | (pending) |
 | 2026-05-04 | **Security: bump postcss 8.5.8 → 8.5.10** (dependabot): fixes GHSA-qx2v-qp2m-jg93 / CVE-2026-41305 (XSS via unescaped `</style>`, medium). Transitive dev dep. | — | #166 |
 | 2026-05-04 | **Fix: require Program when journey is attached to compliance tool**: Stillson tool was saved with `journeyId` + `journeyMilestones` but `programId: null`, which left the Mark Complete button disabled for journey milestones. Added Zod `.refine()` + editor-side validation so the misconfig can't slip through again. | — | (pending) |
-| 2026-04-09 | **Fix thumbnail image fallback**: Added `onError` handlers to all 6 image-rendering locations so broken MP thumbnails gracefully fall back to initials instead of broken image icons. | — | #157 |
-| 2026-04-09 | **Sort options for journey & compliance tools**: Added sort dropdown (Last Name, Most Completed, Least Completed) to all processing pages. Shared `sortCards()` utility + `ProcessingSortSelect` component. 6 new tests. | — | #158 |
-| 2026-04-08 | **Test coverage: 88 new tests across 8 files** (236→324 total). Adapted upstream PR #45 for our fork's auth/security patterns. Covers: user-context, session-context, user-menu sign-out, contact-lookup scoring/sorting, contact-logs CRUD actions, contactService with sanitization, contactLogService with Central Time date conversion, MinistryPlatformProvider delegation. | — | #156 |
-| 2026-04-08 | **Upstream sync through PR #55**: Incorporated MP data safety write-confirmation rule into `.claude/rules/security.md`. Updated sync log. | — | — |
 
 ## Planned
 
@@ -24,6 +21,7 @@ Quick-reference snapshot of current project state. Read this first at session st
 
 - [**#110** — Serving metrics: reconcile adult-only vs all-ages counts](ideas.md#serving-metrics-reconcile-adult-only-vs-all-ages-counts-110)
 - [**#72** — Dashboard subpages per journey step](ideas.md#and-more-specific-dashboard-subpages-72)
+- [**#161** — student leaders](https://github.com/The-Moody-Church/mp-charts/issues/161)
 
 ## Key Architecture Notes
 

--- a/src/components/compliance-processing/compliance-card.tsx
+++ b/src/components/compliance-processing/compliance-card.tsx
@@ -53,7 +53,21 @@ export function ComplianceCard({ participant, onClick }: ComplianceCardProps) {
 
   const hasExpired = checklist.some(c => c.status === "expired");
   const hasExpiring = checklist.some(c => c.status === "expiring_soon");
-  const hasMissing = !isFullyCompliant && !isDiscontinued && checklist.some(c => c.status === "not_started");
+  const hasMissing = checklist.some(c => c.status === "not_started");
+
+  // Single status badge by priority: Missing > Expired > Expiring > Compliant.
+  // Discontinued suppresses the status badge entirely.
+  const statusBadge: { label: string; className: string } | null = isDiscontinued
+    ? null
+    : hasMissing
+      ? { label: "Missing", className: "bg-gray-100 text-gray-600" }
+      : hasExpired
+        ? { label: "Expired", className: "bg-red-100 text-red-700" }
+        : hasExpiring
+          ? { label: "Expiring", className: "bg-orange-100 text-orange-700" }
+          : isFullyCompliant
+            ? { label: "Compliant", className: "bg-green-100 text-green-700" }
+            : null;
 
   const requirementItems = checklist.filter(item => item.type !== "journey_milestone");
   const milestoneItems = checklist.filter(item => item.type === "journey_milestone");
@@ -85,24 +99,9 @@ export function ComplianceCard({ participant, onClick }: ComplianceCardProps) {
               Discontinued
             </span>
           )}
-          {isFullyCompliant && !isDiscontinued && (
-            <span className="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-[10px] font-medium text-green-700">
-              Compliant
-            </span>
-          )}
-          {hasExpired && !isDiscontinued && (
-            <span className="inline-flex items-center rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-medium text-red-700">
-              Expired
-            </span>
-          )}
-          {hasExpiring && !hasExpired && !isDiscontinued && (
-            <span className="inline-flex items-center rounded-full bg-orange-100 px-2 py-0.5 text-[10px] font-medium text-orange-700">
-              Expiring
-            </span>
-          )}
-          {hasMissing && !hasExpired && !hasExpiring && (
-            <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600">
-              Missing
+          {statusBadge && (
+            <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${statusBadge.className}`}>
+              {statusBadge.label}
             </span>
           )}
           {isPaused && (

--- a/src/components/compliance-processing/compliance-card.tsx
+++ b/src/components/compliance-processing/compliance-card.tsx
@@ -55,6 +55,23 @@ export function ComplianceCard({ participant, onClick }: ComplianceCardProps) {
   const hasExpiring = checklist.some(c => c.status === "expiring_soon");
   const hasMissing = !isFullyCompliant && !isDiscontinued && checklist.some(c => c.status === "not_started");
 
+  const requirementItems = checklist.filter(item => item.type !== "journey_milestone");
+  const milestoneItems = checklist.filter(item => item.type === "journey_milestone");
+
+  const renderChecklistItem = (item: ComplianceChecklistItem) => (
+    <div key={item.key} className="flex items-center gap-1.5">
+      <StatusIcon item={item} />
+      <span className={`text-xs truncate ${
+        item.status === "complete" ? "text-gray-700" :
+        item.status === "expired" ? "text-red-500 line-through" :
+        item.status === "expiring_soon" ? "text-orange-600" :
+        "text-gray-400"
+      }`}>
+        {item.label}
+      </span>
+    </div>
+  );
+
   return (
     <Card
       className="cursor-pointer hover:shadow-md transition-shadow py-4 gap-3 relative"
@@ -124,21 +141,26 @@ export function ComplianceCard({ participant, onClick }: ComplianceCardProps) {
           {completedCount}/{totalCount} complete
         </div>
 
-        {/* Checklist */}
-        <div className="w-full space-y-1">
-          {checklist.map((item) => (
-            <div key={item.key} className="flex items-center gap-1.5">
-              <StatusIcon item={item} />
-              <span className={`text-xs truncate ${
-                item.status === "complete" ? "text-gray-700" :
-                item.status === "expired" ? "text-red-500 line-through" :
-                item.status === "expiring_soon" ? "text-orange-600" :
-                "text-gray-400"
-              }`}>
-                {item.label}
-              </span>
+        {/* Checklist — split into Requirements and Milestones when both are present */}
+        <div className="w-full space-y-2">
+          {requirementItems.length > 0 && (
+            <div className="space-y-1">
+              {milestoneItems.length > 0 && (
+                <div className="text-[10px] font-semibold uppercase tracking-wide text-gray-500">
+                  Requirements
+                </div>
+              )}
+              {requirementItems.map(renderChecklistItem)}
             </div>
-          ))}
+          )}
+          {milestoneItems.length > 0 && (
+            <div className="space-y-1">
+              <div className="text-[10px] font-semibold uppercase tracking-wide text-gray-500">
+                Milestones
+              </div>
+              {milestoneItems.map(renderChecklistItem)}
+            </div>
+          )}
         </div>
 
         {/* Group name badges */}

--- a/src/components/contact-lookup-details/actions.ts
+++ b/src/components/contact-lookup-details/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { requireFeatureAccess } from '@/lib/authorization';
-import { ContactLookupDetails, ContactLogDisplay, ContactLogMadeBy, HouseholdMember, ContactBadges } from '@/lib/dto';
+import { ContactLookupDetails, ContactLogDisplay, ContactLogMadeBy, HouseholdMember, ContactBadges, ContactGroupMembership } from '@/lib/dto';
 import { ContactService } from '@/services/contactService';
 import { ContactLogService } from '@/services/contactLogService';
 import { MPHelper } from '@/lib/providers/ministry-platform';
@@ -134,6 +134,22 @@ export async function getContactBadges(contactId: number, householdPositionId?: 
   } catch (error) {
     console.error('Error fetching contact badges:', error);
     return { membershipStatus: null, membershipStatusId: null, membershipDate: null, inGroup: false, serving: false, lastActivity: null, ageGradeGroups: [] };
+  }
+}
+
+export async function getContactGroups(contactId: number): Promise<ContactGroupMembership[]> {
+  try {
+    await requireFeatureAccess("contact-lookup");
+
+    if (!contactId || contactId <= 0) {
+      throw new Error('Valid contact ID is required');
+    }
+
+    const contactService = await ContactService.getInstance();
+    return contactService.getContactGroupMemberships(contactId);
+  } catch (error) {
+    console.error('Error fetching contact groups:', error);
+    return [];
   }
 }
 

--- a/src/components/contact-lookup-details/contact-lookup-details.tsx
+++ b/src/components/contact-lookup-details/contact-lookup-details.tsx
@@ -230,10 +230,12 @@ export const ContactLookupDetails: React.FC<ContactLookupDetailsProps> = ({
     });
   };
 
-  const handleToggleGroups = async () => {
+  const handleToggleGroups = async (scroll = false) => {
     const next = !groupsOpen;
     setGroupsOpen(next);
-    if (next && groups === null && contact?.Contact_ID && !groupsLoading) {
+    if (!next) return;
+
+    if (groups === null && contact?.Contact_ID && !groupsLoading) {
       setGroupsLoading(true);
       try {
         const result = await getContactGroups(contact.Contact_ID);
@@ -241,6 +243,19 @@ export const ContactLookupDetails: React.FC<ContactLookupDetailsProps> = ({
       } finally {
         setGroupsLoading(false);
       }
+    }
+
+    if (scroll) {
+      // Wait two frames so the React commit + paint with the loaded list
+      // has happened before we measure scroll position.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          document.getElementById("contact-groups-section")?.scrollIntoView({
+            behavior: "smooth",
+            block: "start",
+          });
+        });
+      });
     }
   };
 
@@ -397,7 +412,7 @@ export const ContactLookupDetails: React.FC<ContactLookupDetailsProps> = ({
                   {badges.inGroup && (
                     <button
                       type="button"
-                      onClick={handleToggleGroups}
+                      onClick={() => handleToggleGroups(true)}
                       className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium bg-emerald-100 text-emerald-800 hover:bg-emerald-200 transition-colors cursor-pointer"
                       aria-expanded={groupsOpen}
                       aria-controls="contact-groups-section"
@@ -409,7 +424,7 @@ export const ContactLookupDetails: React.FC<ContactLookupDetailsProps> = ({
                   {badges.serving && (
                     <button
                       type="button"
-                      onClick={handleToggleGroups}
+                      onClick={() => handleToggleGroups(true)}
                       className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium bg-emerald-100 text-emerald-800 hover:bg-emerald-200 transition-colors cursor-pointer"
                       aria-expanded={groupsOpen}
                       aria-controls="contact-groups-section"
@@ -613,59 +628,6 @@ export const ContactLookupDetails: React.FC<ContactLookupDetailsProps> = ({
         </div>
       </div>
 
-      {/* Groups Section */}
-      {(badges?.inGroup || badges?.serving) && (
-        <div id="contact-groups-section" className="bg-white shadow rounded-lg">
-          <div className="px-4 py-5 sm:p-6">
-            <button
-              onClick={handleToggleGroups}
-              className="flex items-center gap-2 w-full text-left"
-              aria-expanded={groupsOpen}
-            >
-              <svg
-                className={`h-4 w-4 text-gray-500 transition-transform ${groupsOpen ? "rotate-90" : ""}`}
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
-              </svg>
-              <h2 className="text-lg font-semibold text-gray-900">
-                Groups{groups ? ` (${groups.length})` : ""}
-              </h2>
-            </button>
-
-            {groupsOpen && (
-              <div className="mt-4">
-                {groupsLoading && (
-                  <div className="text-sm text-gray-500">Loading groups…</div>
-                )}
-                {!groupsLoading && groups && groups.length === 0 && (
-                  <div className="text-sm text-gray-500">No current group memberships.</div>
-                )}
-                {!groupsLoading && groups && groups.length > 0 && (
-                  <ul className="divide-y divide-gray-100 border border-gray-100 rounded-md overflow-hidden">
-                    {groups.map((g) => (
-                      <li key={g.Group_Participant_ID} className="px-3 py-2">
-                        <div className="text-sm font-medium text-gray-900 truncate">{g.Group_Name}</div>
-                        <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-gray-500">
-                          {g.Group_Type && <span>{g.Group_Type}</span>}
-                          {g.Role && <span>&middot; {g.Role}</span>}
-                          {g.Start_Date && (
-                            <span>&middot; Joined {parseLocalDate(g.Start_Date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}</span>
-                          )}
-                        </div>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
-            )}
-          </div>
-        </div>
-      )}
-
       {/* Family Section */}
       {familyMembers.length > 0 && (
         <div className="bg-white shadow rounded-lg">
@@ -725,6 +687,59 @@ export const ContactLookupDetails: React.FC<ContactLookupDetailsProps> = ({
                     </Link>
                   );
                 })}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Groups Section */}
+      {(badges?.inGroup || badges?.serving) && (
+        <div id="contact-groups-section" className="bg-white shadow rounded-lg scroll-mt-6">
+          <div className="px-4 py-5 sm:p-6">
+            <button
+              onClick={() => handleToggleGroups(false)}
+              className="flex items-center gap-2 w-full text-left"
+              aria-expanded={groupsOpen}
+            >
+              <svg
+                className={`h-4 w-4 text-gray-500 transition-transform ${groupsOpen ? "rotate-90" : ""}`}
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+              </svg>
+              <h2 className="text-lg font-semibold text-gray-900">
+                Groups{groups ? ` (${groups.length})` : ""}
+              </h2>
+            </button>
+
+            {groupsOpen && (
+              <div className="mt-4">
+                {groupsLoading && (
+                  <div className="text-sm text-gray-500">Loading groups…</div>
+                )}
+                {!groupsLoading && groups && groups.length === 0 && (
+                  <div className="text-sm text-gray-500">No current group memberships.</div>
+                )}
+                {!groupsLoading && groups && groups.length > 0 && (
+                  <ul className="divide-y divide-gray-100 border border-gray-100 rounded-md overflow-hidden">
+                    {groups.map((g) => (
+                      <li key={g.Group_Participant_ID} className="px-3 py-2">
+                        <div className="text-sm font-medium text-gray-900 truncate">{g.Group_Name}</div>
+                        <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-gray-500">
+                          {g.Group_Type && <span>{g.Group_Type}</span>}
+                          {g.Role && <span>&middot; {g.Role}</span>}
+                          {g.Start_Date && (
+                            <span>&middot; Joined {parseLocalDate(g.Start_Date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}</span>
+                          )}
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </div>
             )}
           </div>

--- a/src/components/contact-lookup-details/contact-lookup-details.tsx
+++ b/src/components/contact-lookup-details/contact-lookup-details.tsx
@@ -3,8 +3,8 @@
 import React, { useState, useEffect, useRef } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { getContactDetails, getContactLogsByContactId, getHouseholdMembers, getContactBadges, uploadContactLookupPhoto } from "./actions";
-import { ContactLookupDetails as ContactLookupDetailsType, ContactLogDisplay, HouseholdMember, ContactBadges } from "@/lib/dto";
+import { getContactDetails, getContactLogsByContactId, getHouseholdMembers, getContactBadges, getContactGroups, uploadContactLookupPhoto } from "./actions";
+import { ContactLookupDetails as ContactLookupDetailsType, ContactLogDisplay, HouseholdMember, ContactBadges, ContactGroupMembership } from "@/lib/dto";
 import { ContactLogs } from "@/components/contact-logs";
 import { getCurrentUserMpUserId, createAutoContactLog } from "@/components/contact-logs/actions";
 import { ContactLinks, DetailModalPhotoUpload } from "@/components/processing";
@@ -119,6 +119,9 @@ export const ContactLookupDetails: React.FC<ContactLookupDetailsProps> = ({
   const [familyMembers, setFamilyMembers] = useState<HouseholdMember[]>([]);
   const [imgErrors, setImgErrors] = useState<Set<string>>(new Set());
   const [familyOpen, setFamilyOpen] = useState(true);
+  const [groups, setGroups] = useState<ContactGroupMembership[] | null>(null);
+  const [groupsOpen, setGroupsOpen] = useState(false);
+  const [groupsLoading, setGroupsLoading] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [photoUploading, setPhotoUploading] = useState(false);
@@ -136,6 +139,8 @@ export const ContactLookupDetails: React.FC<ContactLookupDetailsProps> = ({
     try {
       setLoading(true);
       setError(null);
+      setGroups(null);
+      setGroupsOpen(false);
 
       const contactDetails = await getContactDetails(guid);
       setContact(contactDetails);
@@ -223,6 +228,20 @@ export const ContactLookupDetails: React.FC<ContactLookupDetailsProps> = ({
       setLinkCopied(true);
       setTimeout(() => setLinkCopied(false), 2000);
     });
+  };
+
+  const handleToggleGroups = async () => {
+    const next = !groupsOpen;
+    setGroupsOpen(next);
+    if (next && groups === null && contact?.Contact_ID && !groupsLoading) {
+      setGroupsLoading(true);
+      try {
+        const result = await getContactGroups(contact.Contact_ID);
+        setGroups(result);
+      } finally {
+        setGroupsLoading(false);
+      }
+    }
   };
 
   const refreshLogs = async () => {
@@ -376,14 +395,28 @@ export const ContactLookupDetails: React.FC<ContactLookupDetailsProps> = ({
                     </span>
                   )}
                   {badges.inGroup && (
-                    <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium bg-emerald-100 text-emerald-800">
+                    <button
+                      type="button"
+                      onClick={handleToggleGroups}
+                      className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium bg-emerald-100 text-emerald-800 hover:bg-emerald-200 transition-colors cursor-pointer"
+                      aria-expanded={groupsOpen}
+                      aria-controls="contact-groups-section"
+                      title="Click to see all current group memberships"
+                    >
                       In a Group
-                    </span>
+                    </button>
                   )}
                   {badges.serving && (
-                    <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium bg-emerald-100 text-emerald-800">
+                    <button
+                      type="button"
+                      onClick={handleToggleGroups}
+                      className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium bg-emerald-100 text-emerald-800 hover:bg-emerald-200 transition-colors cursor-pointer"
+                      aria-expanded={groupsOpen}
+                      aria-controls="contact-groups-section"
+                      title="Click to see all current group memberships"
+                    >
                       Serving
-                    </span>
+                    </button>
                   )}
                   {badges.lastActivity && (
                     <span
@@ -579,6 +612,59 @@ export const ContactLookupDetails: React.FC<ContactLookupDetailsProps> = ({
           </div>
         </div>
       </div>
+
+      {/* Groups Section */}
+      {(badges?.inGroup || badges?.serving) && (
+        <div id="contact-groups-section" className="bg-white shadow rounded-lg">
+          <div className="px-4 py-5 sm:p-6">
+            <button
+              onClick={handleToggleGroups}
+              className="flex items-center gap-2 w-full text-left"
+              aria-expanded={groupsOpen}
+            >
+              <svg
+                className={`h-4 w-4 text-gray-500 transition-transform ${groupsOpen ? "rotate-90" : ""}`}
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+              </svg>
+              <h2 className="text-lg font-semibold text-gray-900">
+                Groups{groups ? ` (${groups.length})` : ""}
+              </h2>
+            </button>
+
+            {groupsOpen && (
+              <div className="mt-4">
+                {groupsLoading && (
+                  <div className="text-sm text-gray-500">Loading groups…</div>
+                )}
+                {!groupsLoading && groups && groups.length === 0 && (
+                  <div className="text-sm text-gray-500">No current group memberships.</div>
+                )}
+                {!groupsLoading && groups && groups.length > 0 && (
+                  <ul className="divide-y divide-gray-100 border border-gray-100 rounded-md overflow-hidden">
+                    {groups.map((g) => (
+                      <li key={g.Group_Participant_ID} className="px-3 py-2">
+                        <div className="text-sm font-medium text-gray-900 truncate">{g.Group_Name}</div>
+                        <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-gray-500">
+                          {g.Group_Type && <span>{g.Group_Type}</span>}
+                          {g.Role && <span>&middot; {g.Role}</span>}
+                          {g.Start_Date && (
+                            <span>&middot; Joined {parseLocalDate(g.Start_Date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}</span>
+                          )}
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
 
       {/* Family Section */}
       {familyMembers.length > 0 && (

--- a/src/lib/dto/contacts.ts
+++ b/src/lib/dto/contacts.ts
@@ -59,3 +59,15 @@ export interface ContactBadges {
   lastActivity: string | null;
   ageGradeGroups: string[];
 }
+
+export interface ContactGroupMembership {
+  Group_Participant_ID: number;
+  Group_ID: number;
+  Group_Name: string;
+  Group_Type: string | null;
+  Group_Type_ID: number | null;
+  Role: string | null;
+  Group_Role_ID: number | null;
+  Start_Date: string | null;
+  End_Date: string | null;
+}

--- a/src/services/contactService.test.ts
+++ b/src/services/contactService.test.ts
@@ -371,4 +371,57 @@ describe('ContactService', () => {
       expect(badges.serving).toBe(false);
     });
   });
+
+  describe('getContactGroupMemberships', () => {
+    it('returns empty array when contact has no participant record', async () => {
+      mockGetTableRecords.mockImplementation((params: { table: string }) => {
+        if (params.table === 'Participants') return Promise.resolve([]);
+        return Promise.resolve([]);
+      });
+
+      const service = await ContactService.getInstance();
+      const result = await service.getContactGroupMemberships(42);
+
+      expect(result).toEqual([]);
+      // Should not query Group_Participants when there's no Participant
+      const calls = mockGetTableRecords.mock.calls.map(c => c[0].table);
+      expect(calls).toEqual(['Participants']);
+    });
+
+    it('queries Group_Participants for active memberships and returns the records', async () => {
+      const memberships = [
+        {
+          Group_Participant_ID: 1, Group_ID: 100, Group_Name: 'Tuesday Small Group',
+          Group_Type_ID: 1, Group_Type: 'Small Group',
+          Group_Role_ID: 2, Role: 'Member',
+          Start_Date: '2025-01-01', End_Date: null,
+        },
+        {
+          Group_Participant_ID: 2, Group_ID: 200, Group_Name: 'Worship Team',
+          Group_Type_ID: 2, Group_Type: 'Ministry',
+          Group_Role_ID: 16, Role: 'Servant',
+          Start_Date: '2024-09-01', End_Date: null,
+        },
+      ];
+
+      mockGetTableRecords.mockImplementation((params: { table: string }) => {
+        if (params.table === 'Participants') return Promise.resolve([{ Participant_ID: 999 }]);
+        if (params.table === 'Group_Participants') return Promise.resolve(memberships);
+        return Promise.resolve([]);
+      });
+
+      const service = await ContactService.getInstance();
+      const result = await service.getContactGroupMemberships(42);
+
+      expect(result).toEqual(memberships);
+
+      // Verify the Group_Participants query filters by participant + active dates on both
+      // Group_Participants and the parent Group.
+      const gpCall = mockGetTableRecords.mock.calls.find(c => c[0].table === 'Group_Participants');
+      expect(gpCall).toBeDefined();
+      expect(gpCall![0].filter).toContain('Participant_ID IN (999)');
+      expect(gpCall![0].filter).toContain('Group_Participants.[Start_Date]');
+      expect(gpCall![0].filter).toContain('Group_ID_Table.[Start_Date]');
+    });
+  });
 });

--- a/src/services/contactService.ts
+++ b/src/services/contactService.ts
@@ -1,4 +1,4 @@
-import { ContactSearch, ContactLookupDetails, HouseholdMember, ContactBadges } from "@/lib/dto";
+import { ContactSearch, ContactLookupDetails, HouseholdMember, ContactBadges, ContactGroupMembership } from "@/lib/dto";
 import { MPHelper } from "@/lib/providers/ministry-platform";
 import { sanitizeFilterValue, sanitizeGuid, sanitizeIds } from "@/lib/providers/ministry-platform/utils/filter-sanitize";
 
@@ -273,6 +273,33 @@ export class ContactService {
       top: 1,
     });
     return milestones.length > 0 ? milestones[0].Date_Accomplished ?? null : null;
+  }
+
+  /**
+   * Returns all currently-active group memberships for a contact, keyed off the contact's
+   * Participant_Record. "Active" means today is between Group_Participants.Start_Date and End_Date,
+   * AND the parent Group itself is active over the same window.
+   */
+  public async getContactGroupMemberships(contactId: number): Promise<ContactGroupMembership[]> {
+    const safeContactId = sanitizeIds([contactId]);
+
+    const participants = await this.mp!.getTableRecords<{ Participant_ID: number }>({
+      table: "Participants",
+      filter: `Contact_ID IN (${safeContactId})`,
+      select: "Participant_ID",
+    });
+
+    if (participants.length === 0) return [];
+
+    const safeParticipantIds = sanitizeIds(participants.map(p => p.Participant_ID));
+    const today = new Date().toISOString().split('T')[0];
+
+    return this.mp!.getTableRecords<ContactGroupMembership>({
+      table: "Group_Participants",
+      filter: `Participant_ID IN (${safeParticipantIds}) AND Group_Participants.[Start_Date] <= '${today}' AND (Group_Participants.[End_Date] IS NULL OR Group_Participants.[End_Date] >= '${today}') AND Group_ID_Table.[Start_Date] <= '${today}' AND (Group_ID_Table.[End_Date] IS NULL OR Group_ID_Table.[End_Date] >= '${today}')`,
+      select: "Group_Participant_ID, Group_Participants.[Group_ID], Group_ID_Table.[Group_Name], Group_ID_Table.[Group_Type_ID], Group_ID_Table_Group_Type_ID_Table.[Group_Type], Group_Participants.[Group_Role_ID], Group_Role_ID_Table.[Role_Title] AS Role, Group_Participants.[Start_Date], Group_Participants.[End_Date]",
+      orderBy: "Group_ID_Table_Group_Type_ID_Table.[Group_Type], Group_ID_Table.[Group_Name]",
+    });
   }
 
   public async uploadContactPhoto(


### PR DESCRIPTION
## Summary

Closes #162 and #163.

- **#162** — *see all groups*: Adds a **Groups** section to the contact lookup detail page that lists every active Group_Participant for the contact (Group Name, Type, Role, Joined date). The "In a Group" and "Serving" badges are now buttons that toggle the section open and lazy-load the data on first expansion.
- **#163** — *Card Summaries should have sections*: Compliance cards now split the checklist into **Requirements** (`type !== 'journey_milestone'`) and **Milestones** (`type === 'journey_milestone'`) sections — mirroring the split already in the detail modal. Tools without journey milestones (e.g., `active-teachers-and-volunteers`) keep the original single-list layout.

### Implementation notes

- New `ContactGroupMembership` DTO + `ContactService.getContactGroupMemberships(contactId)` service method. Looks up the Participant_Record(s), then queries `Group_Participants` filtered to currently-active rows on both the Group_Participant and the parent Group, with FK joins to `Group_ID_Table` (Group_Name, Group_Type) and `Group_Role_ID_Table` (Role_Title).
- New `getContactGroups` server action (gated by `requireFeatureAccess("contact-lookup")`).
- Groups section state resets in `fetchContactDetails` so navigating between contacts doesn't show stale data.
- No "View in MP" link on Group rows yet — I don't have a confirmed MP page ID for Groups. Easy to add later.

## Security Review

- **Filter sanitization**: `getContactGroupMemberships` uses `sanitizeIds([contactId])` and `sanitizeIds(participants.map(p => p.Participant_ID))` for all interpolated IDs. Date interpolation uses `new Date().toISOString().split('T')[0]` (YYYY-MM-DD only — safe). No `.join()` in filter context.
- **Authorization**: server action calls `requireFeatureAccess("contact-lookup")` before any data access.
- **PII logging**: `console.error` logs operation context only, no PII payload.
- **Read-only**: no MP write operations introduced.
- **No env vars / file uploads / redirects / auth changes**.

## Test plan

- [x] `npm run test:run` — 460/460 pass (including 2 new cases for `getContactGroupMemberships`)
- [ ] Manual: visit `/contact-lookup/<guid>` for a contact who is in a group; click the "In a Group" badge → Groups section expands and lists current memberships
- [ ] Manual: navigate to a different contact via the search; confirm Groups state resets (no stale list flash)
- [ ] Manual: visit `/compliance/stillson-residents` (a tool with both `requirements` and `journeyMilestones`); confirm card shows "REQUIREMENTS" and "MILESTONES" subheaders
- [ ] Manual: visit `/compliance/active-teachers-and-volunteers` (no journey milestones); confirm card layout unchanged