### PR TITLE
feat(summer-blast): new tool for event signups + volunteers

### DIFF
--- a/data/summer-blast-config.json
+++ b/data/summer-blast-config.json
@@ -1,0 +1,235 @@
+{
+  "eventName": "Summer Blast",
+  "eventEndDate": "2026-07-31",
+  "intakeOpportunityId": 85,
+  "trackingGroupId": 1031,
+  "tempGroupRoleId": 1,
+  "cppFormId": 83,
+  "mandatedReporterCertId": 10,
+  "intakeRequirements": [
+    {
+      "requirementId": 0,
+      "label": "Background Check",
+      "type": "background_check",
+      "sortOrder": 1
+    },
+    {
+      "requirementId": 83,
+      "label": "Child Protection Policy Agreement",
+      "type": "form",
+      "sortOrder": 2
+    },
+    {
+      "requirementId": 10,
+      "label": "Mandated Reporter",
+      "type": "certification",
+      "sortOrder": 3
+    }
+  ],
+  "roleConfigs": [
+    {
+      "groupRoleId": 42,
+      "label": "Summer Blast Volunteer - Chow",
+      "requirements": [
+        {
+          "requirementId": 83,
+          "label": "Child Protection Policy Agreement",
+          "type": "form",
+          "sortOrder": 1
+        }
+      ]
+    },
+    {
+      "groupRoleId": 43,
+      "label": "Summer Blast Volunteer - Parking",
+      "requirements": [
+        {
+          "requirementId": 83,
+          "label": "Child Protection Policy Agreement",
+          "type": "form",
+          "sortOrder": 1
+        }
+      ]
+    },
+    {
+      "groupRoleId": 44,
+      "label": "Summer Blast Volunteer - Group Leader",
+      "requirements": [
+        {
+          "requirementId": 0,
+          "label": "Background Check",
+          "type": "background_check",
+          "sortOrder": 1
+        },
+        {
+          "requirementId": 83,
+          "label": "Child Protection Policy Agreement",
+          "type": "form",
+          "sortOrder": 2
+        },
+        {
+          "requirementId": 10,
+          "label": "Mandated Reporter",
+          "type": "certification",
+          "sortOrder": 3
+        }
+      ]
+    },
+    {
+      "groupRoleId": 45,
+      "label": "Summer Blast Lead Team",
+      "requirements": [
+        {
+          "requirementId": 0,
+          "label": "Background Check",
+          "type": "background_check",
+          "sortOrder": 1
+        },
+        {
+          "requirementId": 83,
+          "label": "Child Protection Policy Agreement",
+          "type": "form",
+          "sortOrder": 2
+        },
+        {
+          "requirementId": 10,
+          "label": "Mandated Reporter",
+          "type": "certification",
+          "sortOrder": 3
+        }
+      ]
+    },
+    {
+      "groupRoleId": 46,
+      "label": "Summer Blast Station Leader",
+      "requirements": [
+        {
+          "requirementId": 0,
+          "label": "Background Check",
+          "type": "background_check",
+          "sortOrder": 1
+        },
+        {
+          "requirementId": 83,
+          "label": "Child Protection Policy Agreement",
+          "type": "form",
+          "sortOrder": 2
+        },
+        {
+          "requirementId": 10,
+          "label": "Mandated Reporter",
+          "type": "certification",
+          "sortOrder": 3
+        }
+      ]
+    },
+    {
+      "groupRoleId": 47,
+      "label": "Summer Blast Volunteer - Crew Leader",
+      "requirements": [
+        {
+          "requirementId": 0,
+          "label": "Background Check",
+          "type": "background_check",
+          "sortOrder": 1
+        },
+        {
+          "requirementId": 83,
+          "label": "Child Protection Policy Agreement",
+          "type": "form",
+          "sortOrder": 2
+        },
+        {
+          "requirementId": 10,
+          "label": "Mandated Reporter",
+          "type": "certification",
+          "sortOrder": 3
+        }
+      ]
+    },
+    {
+      "groupRoleId": 48,
+      "label": "Summer Blast Volunteer - Nursery",
+      "requirements": [
+        {
+          "requirementId": 0,
+          "label": "Background Check",
+          "type": "background_check",
+          "sortOrder": 1
+        },
+        {
+          "requirementId": 83,
+          "label": "Child Protection Policy Agreement",
+          "type": "form",
+          "sortOrder": 2
+        },
+        {
+          "requirementId": 10,
+          "label": "Mandated Reporter",
+          "type": "certification",
+          "sortOrder": 3
+        }
+      ]
+    },
+    {
+      "groupRoleId": 49,
+      "label": "Summer Blast Volunteer - Registration",
+      "requirements": [
+        {
+          "requirementId": 83,
+          "label": "Child Protection Policy Agreement",
+          "type": "form",
+          "sortOrder": 1
+        }
+      ]
+    },
+    {
+      "groupRoleId": 50,
+      "label": "Summer Blast Volunteer - Prayer Team",
+      "requirements": [
+        {
+          "requirementId": 83,
+          "label": "Child Protection Policy Agreement",
+          "type": "form",
+          "sortOrder": 1
+        }
+      ]
+    },
+    {
+      "groupRoleId": 51,
+      "label": "Summer Blast Youth Assistant",
+      "requirements": [
+        {
+          "requirementId": 0,
+          "label": "Background Check",
+          "type": "background_check",
+          "sortOrder": 1
+        },
+        {
+          "requirementId": 83,
+          "label": "Child Protection Policy Agreement",
+          "type": "form",
+          "sortOrder": 2
+        },
+        {
+          "requirementId": 10,
+          "label": "Mandated Reporter",
+          "type": "certification",
+          "sortOrder": 3
+        }
+      ]
+    },
+    {
+      "groupRoleId": 52,
+      "label": "Summer Blast - Volunteer Room",
+      "requirements": [
+        {
+          "requirementId": 83,
+          "label": "Child Protection Policy Agreement",
+          "type": "form",
+          "sortOrder": 1
+        }
+      ]
+    }
+  ]
+}

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -78,6 +78,9 @@ Ideas and enhancements for the MPNext project. This file syncs bidirectionally w
 
 ## Features
 
+### ~~Summer Blast Volunteers~~ ✅ COMPLETED
+New bespoke route at `/summer-blast-volunteers` for managing the annual Summer Blast event. Two tabs: **Signups** (open Opportunity 85 Responses) and **Volunteers** (active Group 1031 Group_Participants). Cards show CPP / Mandated Reporter / Background Check status with a custom "Will Expire" badge for requirements that are currently valid but expire before 2026-07-31 (the day after the event ends). Click a signup card to add CPP / MR quickly and then "Added to SB Spreadsheet" — which creates a Group_Participant in Group 1031 (using the chosen Group_Role_ID 42-52, or Temp role 1 if none selected) and closes the Response. Tab 2 cards show role-specific requirements (configured per role in `data/summer-blast-config.json`; Temp falls back to BG+CPP+MR) and a "Remove from group" button that end-dates the participant without reopening the Response. Cache-warmed alongside dashboard and contact-search caches.
+
 ### and more specific dashboard subpages ([#72](https://github.com/The-Moody-Church/mp-charts/issues/72))
 For each step in the journey of a lifetime, add sub pages with more detailed charts.
 - Know God

--- a/docs/sessions/session-summary-2026-05-13.md
+++ b/docs/sessions/session-summary-2026-05-13.md
@@ -1,0 +1,67 @@
+# Session Summary — 2026-05-13
+
+## Objective
+
+Build a new "Summer Blast Volunteers" tool to manage signups and volunteers for the annual Summer Blast event (2026-07-27 through 2026-07-30).
+
+## Status: COMPLETED — ready for PR
+
+## What shipped
+
+A bespoke route at `/summer-blast-volunteers` with two tabs:
+
+1. **Signups (intake)** — open Opportunity 85 Responses (`Closed = false`). Each card shows compliance status for the three event requirements (Background Check, CPP form, Mandated Reporter cert). Cards have a custom "Will Expire" badge — orange/amber, distinct from the existing compliance "Expiring" (30-day) — that fires whenever any requirement is currently valid but expires before **2026-07-31** (day after the event ends). Clicking a card opens a modal with a CPP-add and MR-add panel plus an "Added to SB Spreadsheet" button that:
+   - Resolves Contact_ID → Participant_ID
+   - Creates a `Group_Participants` row in Group 1031 with the chosen Group_Role_ID (or Temp role 1 if none selected)
+   - Updates the `Responses` row to `Closed = true` so the card disappears from Tab 1
+
+2. **Volunteers** — `Group_Participants` rows in Group 1031 (`End_Date IS NULL`). Each card shows role-specific requirements pulled from `data/summer-blast-config.json` (per-role for IDs 42-52; Temp role 1 falls back to intake requirements: BG + CPP + MR). Detail modal has the same CPP/MR quick-add affordances and a "Remove from group" button that end-dates the `Group_Participants` row without reopening the Response.
+
+## Files created
+
+- `data/summer-blast-config.json` — Hand-editable config: event end date, opportunity ID, tracking group, temp role, CPP form ID, MR cert ID, intake requirements, per-role requirements.
+- `src/lib/summer-blast-config.ts` — Zod-validated loader + `getRequirementsForRole` / `getRoleLabel` helpers.
+- `src/lib/dto/summer-blast.ts` — DTOs: `SummerBlastIntakeCard`, `SummerBlastVolunteerCard`, `SummerBlastChecklistItem`.
+- `src/services/summerBlastService.ts` — Singleton service. Public methods: `getIntakeCards`, `getVolunteerCards`, `addToSummerBlast`, `removeFromSummerBlast`, `createCpp`, `createMandatedReporter`. Exports `getEventExpirationStatus` for unit testing.
+- `src/services/summerBlastService.test.ts` — 17 tests covering event-cutoff expiration logic, intake card building, dedup, role-specific requirements, Temp fallback, add/remove behaviors, write call shapes.
+- `src/app/(web)/summer-blast-volunteers/page.tsx` — Suspense + `connection()` page route.
+- `src/components/summer-blast-volunteers/cached-data.ts` — Two `'use cache'` functions (`getCachedSummerBlastIntake`, `getCachedSummerBlastVolunteers`), 6h revalidate / 24h stale, with serviceCache safety net.
+- `src/components/summer-blast-volunteers/actions.ts` — Server actions with `requireFeatureAccess` + `enforceRateLimit("write")` and tag invalidation.
+- `src/components/summer-blast-volunteers/summer-blast-volunteers.tsx` — Main client component (Tabs root).
+- `src/components/summer-blast-volunteers/intake-card.tsx` and `volunteer-card.tsx` — Card variants.
+- `src/components/summer-blast-volunteers/intake-detail-modal.tsx` and `volunteer-detail-modal.tsx` — Detail modals.
+- `src/components/summer-blast-volunteers/will-expire-badge.tsx` — Reusable summary + inline badge.
+- `src/components/summer-blast-volunteers/checklist-icon.tsx` — Status icons.
+- `src/components/summer-blast-volunteers/index.ts` — Barrel.
+
+## Files modified
+
+- `src/lib/dto/index.ts` — Barrel re-export `summer-blast`.
+- `src/lib/authorization.ts` — Added `summer-blast-volunteers` as a `StaticFeature`, default config entry, and inclusion in `getAccessibleFeatures`.
+- `src/lib/cache-warming.ts` — Registered the two new cached functions.
+- `src/components/layout/sidebar.tsx` — Added nav entry (SunIcon).
+- `src/components/home/home-cards.tsx` — Added home card.
+- `data/feature-access.json` — New entry with allowed groups mirroring `compliance:active-teachers-and-volunteers` (29, 32).
+
+## Verification
+
+- `npx vitest run src/services/summerBlastService.test.ts` — 17/17 passing.
+- `npm run test:run` — 477/477 passing (no regressions).
+- `npm run build` — Succeeds. `/summer-blast-volunteers` registered as a PPR route.
+- `npm run lint` — Pre-existing errors only; no new errors from this work.
+- CI security-lint check (`.join` near `filter:`) — clean.
+
+## Decisions (settled during the session)
+
+- **Bespoke route, not configurable compliance tool**: The data source for Tab 1 is `Responses`, not `Group_Participants` — fundamentally different from existing compliance tools. Retrofitting the generic compliance config would have muddied that abstraction.
+- **Cutoff = end of event** (2026-07-31 00:00 CT). Items expiring on the cutoff itself count as "complete" (strict `<` comparison).
+- **Tab 1 filter**: `Opportunity_ID = 85 AND Closed = false`. Closing the Response on "Add to SB" is what makes the card disappear from Tab 1.
+- **Remove does NOT reopen the Response.** End-date the `Group_Participants` row only. If the volunteer needs to come back to Tab 1, an admin reopens the Response manually in MP.
+- **Per-role requirements** (set during the session — verify with Jonathon before go-live): kid-facing roles (44, 45, 46, 47, 48, 51) require BG + CPP + MR; logistics roles (42, 43, 49, 50, 52) require CPP only. Temp role (1) and any unmapped role fall back to BG + CPP + MR.
+- **Will Expire badge styling**: amber (`bg-amber-100 text-amber-800`) + calendar-clock icon, distinct from the orange "Expiring" badge used by compliance for 30-day windows. Summary chip on card top-right; small inline `will expire` chip next to each affected item.
+
+## Follow-ups for Jonathon
+
+1. **Per-role requirements matrix** — sanity-check the assignment above; especially whether Registration (49) and Prayer Team (50) should also need Background Check.
+2. **`feature-access.json` allowed groups** — currently mirrors `compliance:active-teachers-and-volunteers` (groups 29, 32). Adjust if the SB team uses different groups.
+3. **Event date** — config has `2026-07-31` as the cutoff (day after the 7/27-7/30 event). Confirm.

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,16 +2,14 @@
 
 Quick-reference snapshot of current project state. Read this first at session start. For full details on any item, see the relevant session summary in `docs/sessions/`.
 
-**Last updated**: 2026-05-05
+**Last updated**: 2026-05-13
 
 ## Recently Completed
 
 | Date | Work | Issues | PR |
 |------|------|--------|---|
+| 2026-05-13 | **Summer Blast Volunteers tool**: New bespoke route at `/summer-blast-volunteers` with two tabs (open Opportunity 85 signups, active Group 1031 volunteers), event-cutoff "Will Expire" badge (anything expiring before 2026-07-31), CPP/Mandated Reporter quick-add, "Added to SB Spreadsheet" enrollment that creates a Group_Participant and closes the Response, role-specific requirements config (per Group_Role_ID 42-52, with Temp role 1 falling back to BG+CPP+MR). Service + 17 unit tests, cache warming registered. | — | (pending) |
 | 2026-05-05 | **Contact lookup: Groups section + sectioned compliance cards**: Added a "Groups" section to the contact lookup detail page that lists every active Group_Participant for the contact (clickable via the In a Group / Serving badges, lazy-loaded). Compliance cards now split the checklist into Requirements vs Milestones sections. | #162, #163 | (pending) |
-| 2026-05-04 | **CI: bump trivy-action v0.35.0 → v0.36.0**: clears Node.js 20 deprecation warning (v0.36.0 uses `actions/cache@v5.0.5` on Node 24). | — | (pending) |
-| 2026-05-04 | **Security: bump postcss 8.5.8 → 8.5.10** (dependabot): fixes GHSA-qx2v-qp2m-jg93 / CVE-2026-41305 (XSS via unescaped `</style>`, medium). Transitive dev dep. | — | #166 |
-| 2026-05-04 | **Fix: require Program when journey is attached to compliance tool**: Stillson tool was saved with `journeyId` + `journeyMilestones` but `programId: null`, which left the Mark Complete button disabled for journey milestones. Added Zod `.refine()` + editor-side validation so the misconfig can't slip through again. | — | (pending) |
 
 ## Planned
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2278,9 +2278,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
-      "integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2294,9 +2294,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
-      "integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
       "cpu": [
         "arm64"
       ],
@@ -2310,9 +2310,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
-      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
       "cpu": [
         "x64"
       ],
@@ -2326,11 +2326,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
-      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2342,11 +2345,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
-      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2358,11 +2364,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
-      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2374,11 +2383,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
-      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2390,9 +2402,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
-      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
       "cpu": [
         "arm64"
       ],
@@ -2406,9 +2418,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
-      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
       "cpu": [
         "x64"
       ],
@@ -8530,9 +8542,9 @@
       }
     },
     "node_modules/kysely": {
-      "version": "0.28.14",
-      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.14.tgz",
-      "integrity": "sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA==",
+      "version": "0.28.17",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.17.tgz",
+      "integrity": "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
@@ -9192,12 +9204,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
-      "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.3",
+        "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -9211,14 +9223,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.3",
-        "@next/swc-darwin-x64": "16.2.3",
-        "@next/swc-linux-arm64-gnu": "16.2.3",
-        "@next/swc-linux-arm64-musl": "16.2.3",
-        "@next/swc-linux-x64-gnu": "16.2.3",
-        "@next/swc-linux-x64-musl": "16.2.3",
-        "@next/swc-win32-arm64-msvc": "16.2.3",
-        "@next/swc-win32-x64-msvc": "16.2.3",
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/src/app/(web)/summer-blast-volunteers/page.tsx
+++ b/src/app/(web)/summer-blast-volunteers/page.tsx
@@ -1,0 +1,32 @@
+import { Suspense } from "react";
+import { connection } from "next/server";
+import { SummerBlastVolunteers } from "@/components/summer-blast-volunteers";
+import { getSummerBlastConfig } from "@/lib/summer-blast-config";
+
+export default function SummerBlastVolunteersPage() {
+  return (
+    <div className="container mx-auto p-4 sm:p-6 lg:p-8">
+      <Suspense
+        fallback={<div className="text-muted-foreground">Loading Summer Blast volunteers...</div>}
+      >
+        <SummerBlastVolunteersContent />
+      </Suspense>
+    </div>
+  );
+}
+
+async function SummerBlastVolunteersContent() {
+  await connection();
+  const config = getSummerBlastConfig();
+  return (
+    <SummerBlastVolunteers
+      eventName={config.eventName}
+      eventEndDate={config.eventEndDate}
+      roleOptions={config.roleConfigs.map((r) => ({
+        groupRoleId: r.groupRoleId,
+        label: r.label,
+      }))}
+      tempGroupRoleId={config.tempGroupRoleId}
+    />
+  );
+}

--- a/src/components/home/home-cards.tsx
+++ b/src/components/home/home-cards.tsx
@@ -40,6 +40,13 @@ const featureCards: FeatureCard[] = [
     feature: "manage-members",
   },
   {
+    title: "Summer Blast Volunteers",
+    description: "Track signups, volunteer compliance, and group assignments for the Summer Blast event",
+    href: "/summer-blast-volunteers",
+    buttonText: "Manage Volunteers",
+    feature: "summer-blast-volunteers",
+  },
+  {
     title: "Setup",
     description: "Manage which User Groups can access each feature",
     href: "/admin",

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
-import { HomeIcon, UsersIcon, UserGroupIcon, ChartBarIcon, ShieldCheckIcon, MapIcon, CheckBadgeIcon } from "@heroicons/react/24/outline";
+import { HomeIcon, UsersIcon, UserGroupIcon, ChartBarIcon, ShieldCheckIcon, MapIcon, CheckBadgeIcon, SunIcon } from "@heroicons/react/24/outline";
 import { useAuthorization } from "@/hooks/use-authorization";
 import { useUser } from "@/contexts/user-context";
 import type { Feature } from "@/lib/authorization";
@@ -25,6 +25,7 @@ const navigation: NavItem[] = [
   { name: "Dashboard: Journey of a Lifetime", href: "/dashboard", icon: ChartBarIcon, feature: "dashboard" },
   { name: "Contact Lookup", href: "/contact-lookup", icon: UsersIcon, feature: "contact-lookup" },
   { name: "Manage Members", href: "/manage-members", icon: UserGroupIcon, feature: "manage-members" },
+  { name: "Summer Blast Volunteers", href: "/summer-blast-volunteers", icon: SunIcon, feature: "summer-blast-volunteers" },
   { name: "Setup", href: "/admin", icon: ShieldCheckIcon, adminOnly: true },
 ];
 

--- a/src/components/summer-blast-volunteers/actions.ts
+++ b/src/components/summer-blast-volunteers/actions.ts
@@ -4,6 +4,7 @@ import { updateTag } from "next/cache";
 import { getMpUserId } from "@/lib/auth-helpers";
 import { requireFeatureAccess } from "@/lib/authorization";
 import { enforceRateLimit } from "@/lib/rate-limit";
+import { serviceCache } from "@/lib/service-cache";
 import { SummerBlastService } from "@/services/summerBlastService";
 import {
   getCachedSummerBlastIntake,
@@ -19,8 +20,13 @@ import type {
 const FEATURE = "summer-blast-volunteers" as const;
 
 function invalidateAll() {
+  // updateTag invalidates the Next.js 'use cache' framework cache; serviceCache
+  // is our in-memory safety net inside each cached function and must be cleared
+  // separately or it will keep returning the pre-write snapshot.
   updateTag(SUMMER_BLAST_INTAKE_TAG);
   updateTag(SUMMER_BLAST_VOLUNTEERS_TAG);
+  serviceCache.deleteByPrefix(SUMMER_BLAST_INTAKE_TAG);
+  serviceCache.deleteByPrefix(SUMMER_BLAST_VOLUNTEERS_TAG);
 }
 
 export async function getSummerBlastIntake(): Promise<SummerBlastIntakeCard[]> {

--- a/src/components/summer-blast-volunteers/actions.ts
+++ b/src/components/summer-blast-volunteers/actions.ts
@@ -1,0 +1,159 @@
+"use server";
+
+import { updateTag } from "next/cache";
+import { getMpUserId } from "@/lib/auth-helpers";
+import { requireFeatureAccess } from "@/lib/authorization";
+import { enforceRateLimit } from "@/lib/rate-limit";
+import { SummerBlastService } from "@/services/summerBlastService";
+import {
+  getCachedSummerBlastIntake,
+  getCachedSummerBlastVolunteers,
+  SUMMER_BLAST_INTAKE_TAG,
+  SUMMER_BLAST_VOLUNTEERS_TAG,
+} from "./cached-data";
+import type {
+  SummerBlastIntakeCard,
+  SummerBlastVolunteerCard,
+} from "@/lib/dto";
+
+const FEATURE = "summer-blast-volunteers" as const;
+
+function invalidateAll() {
+  updateTag(SUMMER_BLAST_INTAKE_TAG);
+  updateTag(SUMMER_BLAST_VOLUNTEERS_TAG);
+}
+
+export async function getSummerBlastIntake(): Promise<SummerBlastIntakeCard[]> {
+  await requireFeatureAccess(FEATURE);
+  try {
+    return await getCachedSummerBlastIntake();
+  } catch (error) {
+    console.error("Error fetching Summer Blast intake:", error);
+    throw new Error("Failed to load Summer Blast intake");
+  }
+}
+
+export async function getSummerBlastVolunteers(): Promise<SummerBlastVolunteerCard[]> {
+  await requireFeatureAccess(FEATURE);
+  try {
+    return await getCachedSummerBlastVolunteers();
+  } catch (error) {
+    console.error("Error fetching Summer Blast volunteers:", error);
+    throw new Error("Failed to load Summer Blast volunteers");
+  }
+}
+
+export async function addToSummerBlast(formData: FormData): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  try {
+    const session = await requireFeatureAccess(FEATURE);
+    enforceRateLimit(session.user.id, "write");
+
+    const contactId = Number(formData.get("Contact_ID"));
+    const responseId = Number(formData.get("Response_ID"));
+    const rawRole = formData.get("Group_Role_ID");
+    const groupRoleId = rawRole && rawRole !== "" ? Number(rawRole) : null;
+
+    if (!contactId || !responseId) {
+      return { success: false, error: "Missing required fields" };
+    }
+
+    const service = SummerBlastService.getInstance();
+    await service.addToSummerBlast({
+      contactId,
+      responseId,
+      groupRoleId,
+      userId: getMpUserId(session),
+    });
+
+    invalidateAll();
+    return { success: true };
+  } catch (error) {
+    console.error("Error adding to Summer Blast:", error);
+    return { success: false, error: "Failed to add to Summer Blast" };
+  }
+}
+
+export async function removeFromSummerBlast(formData: FormData): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  try {
+    const session = await requireFeatureAccess(FEATURE);
+    enforceRateLimit(session.user.id, "write");
+
+    const groupParticipantId = Number(formData.get("Group_Participant_ID"));
+    if (!groupParticipantId) {
+      return { success: false, error: "Missing required fields" };
+    }
+
+    const service = SummerBlastService.getInstance();
+    await service.removeFromSummerBlast({
+      groupParticipantId,
+      userId: getMpUserId(session),
+    });
+
+    invalidateAll();
+    return { success: true };
+  } catch (error) {
+    console.error("Error removing from Summer Blast:", error);
+    return { success: false, error: "Failed to remove from Summer Blast" };
+  }
+}
+
+export async function createSummerBlastCpp(formData: FormData): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  try {
+    const session = await requireFeatureAccess(FEATURE);
+    enforceRateLimit(session.user.id, "write");
+
+    const contactId = Number(formData.get("Contact_ID"));
+    const responseDate = (formData.get("Response_Date") as string) || new Date().toISOString();
+    if (!contactId) return { success: false, error: "Missing Contact_ID" };
+
+    const service = SummerBlastService.getInstance();
+    await service.createCpp({
+      contactId,
+      responseDate,
+      userId: getMpUserId(session),
+    });
+
+    invalidateAll();
+    return { success: true };
+  } catch (error) {
+    console.error("Error creating CPP form response:", error);
+    return { success: false, error: "Failed to create CPP form response" };
+  }
+}
+
+export async function createSummerBlastMandatedReporter(formData: FormData): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  try {
+    const session = await requireFeatureAccess(FEATURE);
+    enforceRateLimit(session.user.id, "write");
+
+    const participantId = Number(formData.get("Participant_ID"));
+    const completedDate =
+      (formData.get("Certification_Completed") as string) || new Date().toISOString();
+    if (!participantId) return { success: false, error: "Missing Participant_ID" };
+
+    const service = SummerBlastService.getInstance();
+    await service.createMandatedReporter({
+      participantId,
+      completedDate,
+      userId: getMpUserId(session),
+    });
+
+    invalidateAll();
+    return { success: true };
+  } catch (error) {
+    console.error("Error creating Mandated Reporter certification:", error);
+    return { success: false, error: "Failed to create Mandated Reporter certification" };
+  }
+}

--- a/src/components/summer-blast-volunteers/cached-data.ts
+++ b/src/components/summer-blast-volunteers/cached-data.ts
@@ -1,0 +1,38 @@
+// Cached data layer for the Summer Blast Volunteers feature.
+//
+// NOTE: If you add a new 'use cache' function here, you MUST register it in
+// src/lib/cache-warming.ts so it is pre-warmed on container start.
+// See the "Cache Warming" section in CLAUDE.md.
+
+import { cacheLife, cacheTag } from "next/cache";
+import { SummerBlastService } from "@/services/summerBlastService";
+import { serviceCache, CACHE_TTL } from "@/lib/service-cache";
+import type {
+  SummerBlastIntakeCard,
+  SummerBlastVolunteerCard,
+} from "@/lib/dto";
+
+export const SUMMER_BLAST_INTAKE_TAG = "summer-blast-intake";
+export const SUMMER_BLAST_VOLUNTEERS_TAG = "summer-blast-volunteers";
+
+export async function getCachedSummerBlastIntake(): Promise<SummerBlastIntakeCard[]> {
+  "use cache";
+  cacheLife({ revalidate: 21600, stale: 86400 });
+  cacheTag(SUMMER_BLAST_INTAKE_TAG);
+
+  return serviceCache.getOrFetch(SUMMER_BLAST_INTAKE_TAG, CACHE_TTL.STANDARD, async () => {
+    const service = SummerBlastService.getInstance();
+    return service.getIntakeCards();
+  });
+}
+
+export async function getCachedSummerBlastVolunteers(): Promise<SummerBlastVolunteerCard[]> {
+  "use cache";
+  cacheLife({ revalidate: 21600, stale: 86400 });
+  cacheTag(SUMMER_BLAST_VOLUNTEERS_TAG);
+
+  return serviceCache.getOrFetch(SUMMER_BLAST_VOLUNTEERS_TAG, CACHE_TTL.STANDARD, async () => {
+    const service = SummerBlastService.getInstance();
+    return service.getVolunteerCards();
+  });
+}

--- a/src/components/summer-blast-volunteers/checklist-icon.tsx
+++ b/src/components/summer-blast-volunteers/checklist-icon.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import React from "react";
+import type { SummerBlastItemStatus } from "@/lib/dto";
+
+interface Props {
+  status: SummerBlastItemStatus;
+}
+
+export function ChecklistStatusIcon({ status }: Props) {
+  if (status === "complete") {
+    return (
+      <svg
+        className="h-4 w-4 text-green-600 flex-shrink-0"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+      </svg>
+    );
+  }
+  if (status === "expired") {
+    return (
+      <svg
+        className="h-4 w-4 text-red-500 flex-shrink-0"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    );
+  }
+  if (status === "will_expire") {
+    // Calendar-clock icon — distinct from the standard "expiring soon" warning triangle.
+    return (
+      <svg
+        className="h-4 w-4 text-amber-600 flex-shrink-0"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M6.75 3v2.25M17.25 3v2.25M3 8.25h18M5.25 6h13.5A2.25 2.25 0 0121 8.25v9.75A2.25 2.25 0 0118.75 20.25H5.25A2.25 2.25 0 013 18V8.25A2.25 2.25 0 015.25 6z"
+        />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 12v3l2 1" />
+      </svg>
+    );
+  }
+  if (status === "in_progress") {
+    return (
+      <svg
+        className="h-4 w-4 text-yellow-500 flex-shrink-0 animate-pulse"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"
+        />
+      </svg>
+    );
+  }
+  // not_started
+  return <div className="h-4 w-4 rounded-full border-2 border-gray-300 flex-shrink-0" />;
+}

--- a/src/components/summer-blast-volunteers/index.ts
+++ b/src/components/summer-blast-volunteers/index.ts
@@ -1,0 +1,1 @@
+export { SummerBlastVolunteers } from "./summer-blast-volunteers";

--- a/src/components/summer-blast-volunteers/intake-card.tsx
+++ b/src/components/summer-blast-volunteers/intake-card.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import React from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { PersonAvatar } from "@/components/processing";
+import { useRuntimeConfig } from "@/contexts";
+import { getDisplayName } from "@/lib/processing-utils";
+import { ChecklistStatusIcon } from "./checklist-icon";
+import { WillExpireBadge, WillExpireInlineBadge } from "./will-expire-badge";
+import type { SummerBlastIntakeCard, SummerBlastChecklistItem } from "@/lib/dto";
+
+interface Props {
+  card: SummerBlastIntakeCard;
+  onClick: () => void;
+  cutoffDateLabel?: string;
+}
+
+function statusBadge(card: SummerBlastIntakeCard): { label: string; className: string } | null {
+  const hasMissing = card.checklist.some((c) => c.status === "not_started");
+  const hasExpired = card.checklist.some((c) => c.status === "expired");
+  if (hasMissing) return { label: "Missing", className: "bg-gray-100 text-gray-600" };
+  if (hasExpired) return { label: "Expired", className: "bg-red-100 text-red-700" };
+  if (card.hasWillExpire) return null; // WillExpireBadge renders separately
+  if (card.isFullyCompliant) return { label: "Compliant", className: "bg-green-100 text-green-700" };
+  return null;
+}
+
+export function IntakeCard({ card, onClick, cutoffDateLabel }: Props) {
+  const { mpFileUrl } = useRuntimeConfig();
+  const displayName = getDisplayName(card.info.First_Name, card.info.Nickname);
+  const badge = statusBadge(card);
+
+  return (
+    <Card
+      className="cursor-pointer hover:shadow-md transition-shadow py-4 gap-3 relative"
+      onClick={onClick}
+    >
+      <CardContent className="flex flex-col items-center px-3">
+        {/* Status badges (top-right) */}
+        <div className="absolute top-2 right-2 flex items-center gap-1 z-10">
+          {badge && (
+            <span
+              className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${badge.className}`}
+            >
+              {badge.label}
+            </span>
+          )}
+          {card.hasWillExpire && <WillExpireBadge cutoffDate={cutoffDateLabel} />}
+        </div>
+
+        {/* Photo */}
+        <div className="mb-2">
+          <PersonAvatar
+            imageGuid={card.info.Image_GUID}
+            mpFileUrl={mpFileUrl}
+            firstName={card.info.First_Name}
+            nickname={card.info.Nickname}
+            lastName={card.info.Last_Name}
+          />
+        </div>
+
+        {/* Name */}
+        <div className="text-sm font-medium text-center truncate w-full">
+          {displayName} {card.info.Last_Name}
+        </div>
+
+        {/* Progress */}
+        <div className="text-xs text-muted-foreground mb-2">
+          {card.completedCount}/{card.totalCount} complete
+        </div>
+
+        {/* Checklist */}
+        <div className="w-full space-y-1">
+          {card.checklist.map((item) => (
+            <ChecklistRow key={item.key} item={item} />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ChecklistRow({ item }: { item: SummerBlastChecklistItem }) {
+  const textClass =
+    item.status === "complete"
+      ? "text-gray-700"
+      : item.status === "expired"
+        ? "text-red-500 line-through"
+        : item.status === "will_expire"
+          ? "text-amber-700"
+          : "text-gray-400";
+  return (
+    <div className="flex items-center gap-1.5">
+      <ChecklistStatusIcon status={item.status} />
+      <span className={`text-xs truncate ${textClass}`}>{item.label}</span>
+      {item.status === "will_expire" && <WillExpireInlineBadge />}
+    </div>
+  );
+}

--- a/src/components/summer-blast-volunteers/intake-detail-modal.tsx
+++ b/src/components/summer-blast-volunteers/intake-detail-modal.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { PersonAvatar, ContactLinks } from "@/components/processing";
+import { useRuntimeConfig } from "@/contexts";
+import { getDisplayName, formatDate } from "@/lib/processing-utils";
+import { ChecklistStatusIcon } from "./checklist-icon";
+import { WillExpireInlineBadge } from "./will-expire-badge";
+import {
+  addToSummerBlast,
+  createSummerBlastCpp,
+  createSummerBlastMandatedReporter,
+} from "./actions";
+import type {
+  SummerBlastIntakeCard,
+  SummerBlastChecklistItem,
+} from "@/lib/dto";
+
+interface Props {
+  card: SummerBlastIntakeCard | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onUpdate: () => void;
+  roleOptions: { groupRoleId: number; label: string }[];
+  tempGroupRoleId: number;
+  cutoffDateLabel?: string;
+}
+
+export function IntakeDetailModal({
+  card,
+  open,
+  onOpenChange,
+  onUpdate,
+  roleOptions,
+  tempGroupRoleId,
+  cutoffDateLabel,
+}: Props) {
+  const { mpFileUrl } = useRuntimeConfig();
+  const [selectedRoleId, setSelectedRoleId] = useState<string>("");
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [cppDate, setCppDate] = useState(() => new Date().toISOString().split("T")[0]);
+  const [mrDate, setMrDate] = useState(() => new Date().toISOString().split("T")[0]);
+
+  // Reset state on open
+  React.useEffect(() => {
+    if (open) {
+      setSelectedRoleId("");
+      setError(null);
+      setActionLoading(null);
+      setCppDate(new Date().toISOString().split("T")[0]);
+      setMrDate(new Date().toISOString().split("T")[0]);
+    }
+  }, [open]);
+
+  if (!card) return null;
+
+  const { info } = card;
+  const displayName = getDisplayName(info.First_Name, info.Nickname);
+
+  const cppItem = card.checklist.find((c) => c.type === "form");
+  const mrItem = card.checklist.find((c) => c.type === "certification");
+
+  const handleAddCpp = async () => {
+    if (!card) return;
+    setActionLoading("cpp");
+    setError(null);
+    try {
+      const fd = new FormData();
+      fd.set("Contact_ID", String(card.info.Contact_ID));
+      fd.set("Response_Date", `${cppDate}T12:00:00`);
+      const result = await createSummerBlastCpp(fd);
+      if (!result.success) {
+        setError(result.error || "Failed to add CPP");
+      } else {
+        onUpdate();
+      }
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleAddMr = async () => {
+    if (!card) return;
+    setActionLoading("mr");
+    setError(null);
+    try {
+      const fd = new FormData();
+      fd.set("Participant_ID", String(card.info.Participant_ID));
+      fd.set("Certification_Completed", `${mrDate}T12:00:00`);
+      const result = await createSummerBlastMandatedReporter(fd);
+      if (!result.success) {
+        setError(result.error || "Failed to add Mandated Reporter");
+      } else {
+        onUpdate();
+      }
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleAddToSb = async () => {
+    if (!card) return;
+    setActionLoading("add");
+    setError(null);
+    try {
+      const fd = new FormData();
+      fd.set("Contact_ID", String(card.info.Contact_ID));
+      fd.set("Response_ID", String(card.responseId));
+      if (selectedRoleId) fd.set("Group_Role_ID", selectedRoleId);
+      const result = await addToSummerBlast(fd);
+      if (!result.success) {
+        setError(result.error || "Failed to add to Summer Blast");
+      } else {
+        onUpdate();
+        onOpenChange(false);
+      }
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[calc(100vw-1rem)] sm:max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <div className="flex items-center gap-4">
+            <PersonAvatar
+              imageGuid={info.Image_GUID}
+              mpFileUrl={mpFileUrl}
+              firstName={info.First_Name}
+              nickname={info.Nickname}
+              lastName={info.Last_Name}
+            />
+            <div>
+              <DialogTitle>
+                {displayName} {info.Last_Name}
+              </DialogTitle>
+              <DialogDescription>
+                Responded {formatDate(card.responseDate)}
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <ContactLinks
+          email={info.Email_Address}
+          phone={info.Mobile_Phone}
+          contactId={info.Contact_ID}
+        />
+
+        {error && (
+          <div className="text-sm text-red-600 bg-red-50 rounded-md p-2">{error}</div>
+        )}
+
+        {/* Requirements snapshot */}
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold">Requirements</h3>
+          <div className="space-y-1">
+            {card.checklist.map((item) => (
+              <ChecklistRow key={item.key} item={item} />
+            ))}
+          </div>
+        </div>
+
+        {/* Add CPP */}
+        <div className="rounded-md border bg-gray-50 p-3 space-y-2">
+          <div className="flex items-center justify-between">
+            <h4 className="text-sm font-semibold">Add CPP (Child Protection Policy)</h4>
+            {cppItem?.status === "complete" && (
+              <span className="text-xs text-green-700">Current</span>
+            )}
+          </div>
+          <div className="flex flex-wrap items-end gap-2">
+            <div className="flex-1 min-w-[160px]">
+              <Label htmlFor="cpp-date" className="text-xs">
+                Response Date
+              </Label>
+              <input
+                id="cpp-date"
+                type="date"
+                value={cppDate}
+                onChange={(e) => setCppDate(e.target.value)}
+                className="mt-1 w-full rounded-md border bg-white px-2 py-1.5 text-sm"
+              />
+            </div>
+            <Button
+              size="sm"
+              onClick={handleAddCpp}
+              disabled={actionLoading !== null}
+              className="bg-blue-600 hover:bg-blue-700 text-white"
+            >
+              {actionLoading === "cpp" ? "Saving..." : "Add CPP"}
+            </Button>
+          </div>
+        </div>
+
+        {/* Add Mandated Reporter */}
+        <div className="rounded-md border bg-gray-50 p-3 space-y-2">
+          <div className="flex items-center justify-between">
+            <h4 className="text-sm font-semibold">Add Mandated Reporter Certification</h4>
+            {mrItem?.status === "complete" && (
+              <span className="text-xs text-green-700">Current</span>
+            )}
+          </div>
+          <div className="flex flex-wrap items-end gap-2">
+            <div className="flex-1 min-w-[160px]">
+              <Label htmlFor="mr-date" className="text-xs">
+                Completion Date
+              </Label>
+              <input
+                id="mr-date"
+                type="date"
+                value={mrDate}
+                onChange={(e) => setMrDate(e.target.value)}
+                className="mt-1 w-full rounded-md border bg-white px-2 py-1.5 text-sm"
+              />
+            </div>
+            <Button
+              size="sm"
+              onClick={handleAddMr}
+              disabled={actionLoading !== null}
+              className="bg-blue-600 hover:bg-blue-700 text-white"
+            >
+              {actionLoading === "mr" ? "Saving..." : "Add Mandated Reporter"}
+            </Button>
+          </div>
+        </div>
+
+        {/* Add to SB */}
+        <div className="rounded-md border border-blue-200 bg-blue-50 p-3 space-y-2">
+          <h4 className="text-sm font-semibold">Add to SB Spreadsheet</h4>
+          <p className="text-xs text-blue-900">
+            Creates a Group Participant in the Summer Blast Volunteers group and closes
+            this Opportunity Response.
+          </p>
+          <div className="flex flex-wrap items-end gap-2">
+            <div className="flex-1 min-w-[200px]">
+              <Label htmlFor="sb-role" className="text-xs">
+                Group Role (optional — defaults to Temp)
+              </Label>
+              <select
+                id="sb-role"
+                value={selectedRoleId}
+                onChange={(e) => setSelectedRoleId(e.target.value)}
+                className="mt-1 w-full rounded-md border bg-white px-2 py-1.5 text-sm"
+              >
+                <option value="">Temp (reassign later)</option>
+                {roleOptions.map((r) => (
+                  <option key={r.groupRoleId} value={r.groupRoleId}>
+                    {r.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <Button
+              size="sm"
+              onClick={handleAddToSb}
+              disabled={actionLoading !== null}
+              className="bg-emerald-600 hover:bg-emerald-700 text-white"
+            >
+              {actionLoading === "add"
+                ? "Adding..."
+                : `Added to SB Spreadsheet${
+                    !selectedRoleId ? ` (role ${tempGroupRoleId})` : ""
+                  }`}
+            </Button>
+          </div>
+        </div>
+
+        {cutoffDateLabel && (
+          <p className="text-[11px] text-muted-foreground">
+            &ldquo;Will Expire&rdquo; means the requirement is currently valid but expires before{" "}
+            {cutoffDateLabel}.
+          </p>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ChecklistRow({ item }: { item: SummerBlastChecklistItem }) {
+  const textClass =
+    item.status === "complete"
+      ? "text-gray-700"
+      : item.status === "expired"
+        ? "text-red-500 line-through"
+        : item.status === "will_expire"
+          ? "text-amber-700"
+          : "text-gray-500";
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      <ChecklistStatusIcon status={item.status} />
+      <span className={textClass}>{item.label}</span>
+      {item.status === "will_expire" && <WillExpireInlineBadge />}
+      {item.expires && (
+        <span className="ml-auto text-[11px] text-muted-foreground">
+          Expires {formatDate(item.expires)}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/summer-blast-volunteers/summer-blast-volunteers.tsx
+++ b/src/components/summer-blast-volunteers/summer-blast-volunteers.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  ProcessingGrid,
+  ProcessingSearchBar,
+  ProcessingSortSelect,
+} from "@/components/processing";
+import {
+  searchByName,
+  sortCards,
+  type ProcessingSortOption,
+} from "@/lib/processing-utils";
+import { IntakeCard } from "./intake-card";
+import { VolunteerCard } from "./volunteer-card";
+import { IntakeDetailModal } from "./intake-detail-modal";
+import { VolunteerDetailModal } from "./volunteer-detail-modal";
+import { getSummerBlastIntake, getSummerBlastVolunteers } from "./actions";
+import type {
+  SummerBlastIntakeCard,
+  SummerBlastVolunteerCard,
+} from "@/lib/dto";
+
+interface Props {
+  eventName: string;
+  eventEndDate: string;
+  roleOptions: { groupRoleId: number; label: string }[];
+  tempGroupRoleId: number;
+}
+
+function formatCutoffLabel(eventEndDate: string): string {
+  // eventEndDate is "YYYY-MM-DD" in CT.
+  const [y, m, d] = eventEndDate.split("-").map(Number);
+  return new Date(y, m - 1, d).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function SummerBlastVolunteers({
+  eventName,
+  eventEndDate,
+  roleOptions,
+  tempGroupRoleId,
+}: Props) {
+  const cutoffLabel = useMemo(() => formatCutoffLabel(eventEndDate), [eventEndDate]);
+
+  const [activeTab, setActiveTab] = useState("intake");
+  const [intake, setIntake] = useState<SummerBlastIntakeCard[]>([]);
+  const [volunteers, setVolunteers] = useState<SummerBlastVolunteerCard[]>([]);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sortOption, setSortOption] = useState<ProcessingSortOption>("name");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [selectedIntake, setSelectedIntake] = useState<SummerBlastIntakeCard | null>(null);
+  const [intakeModalOpen, setIntakeModalOpen] = useState(false);
+  const [selectedVolunteer, setSelectedVolunteer] = useState<SummerBlastVolunteerCard | null>(null);
+  const [volunteerModalOpen, setVolunteerModalOpen] = useState(false);
+
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [intakeData, volunteerData] = await Promise.all([
+        getSummerBlastIntake(),
+        getSummerBlastVolunteers(),
+      ]);
+      setIntake(intakeData);
+      setVolunteers(volunteerData);
+    } catch (err) {
+      console.error("Failed to load Summer Blast data:", err);
+      setError("Failed to load data. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  const filteredIntake = useMemo(
+    () => sortCards(searchByName(intake, searchQuery), sortOption),
+    [intake, searchQuery, sortOption],
+  );
+  const filteredVolunteers = useMemo(
+    () => sortCards(searchByName(volunteers, searchQuery), sortOption),
+    [volunteers, searchQuery, sortOption],
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">{eventName} Volunteers</h1>
+        <p className="text-muted-foreground">
+          Track signups and volunteers for the event. &ldquo;Will Expire&rdquo; means a
+          requirement is currently valid but expires before {cutoffLabel}.
+        </p>
+      </div>
+
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <TabsList className="w-full sm:w-fit h-auto">
+            <TabsTrigger
+              value="intake"
+              className="flex-1 sm:flex-initial whitespace-normal sm:whitespace-nowrap text-xs sm:text-sm py-1.5"
+            >
+              Signups
+              {intake.length > 0 && (
+                <span className="ml-1.5 rounded-full bg-primary/10 px-2 py-0.5 text-xs">
+                  {intake.length}
+                </span>
+              )}
+            </TabsTrigger>
+            <TabsTrigger
+              value="volunteers"
+              className="flex-1 sm:flex-initial whitespace-normal sm:whitespace-nowrap text-xs sm:text-sm py-1.5"
+            >
+              Volunteers
+              {volunteers.length > 0 && (
+                <span className="ml-1.5 rounded-full bg-primary/10 px-2 py-0.5 text-xs">
+                  {volunteers.length}
+                </span>
+              )}
+            </TabsTrigger>
+          </TabsList>
+          <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-fit">
+            <ProcessingSearchBar value={searchQuery} onChange={setSearchQuery} />
+            <ProcessingSortSelect value={sortOption} onChange={setSortOption} />
+          </div>
+        </div>
+
+        <TabsContent value="intake">
+          <ProcessingGrid
+            items={filteredIntake}
+            loading={loading}
+            error={error}
+            emptyMessage={
+              searchQuery ? "No matching signups found." : "No open signups."
+            }
+            keyExtractor={(c) => c.responseId}
+            renderCard={(c) => (
+              <IntakeCard
+                card={c}
+                onClick={() => {
+                  setSelectedIntake(c);
+                  setIntakeModalOpen(true);
+                }}
+                cutoffDateLabel={cutoffLabel}
+              />
+            )}
+            marginTop
+          />
+        </TabsContent>
+
+        <TabsContent value="volunteers">
+          <ProcessingGrid
+            items={filteredVolunteers}
+            loading={loading}
+            error={error}
+            emptyMessage={
+              searchQuery
+                ? "No matching volunteers found."
+                : "No volunteers yet."
+            }
+            keyExtractor={(c) => c.groupParticipantId}
+            renderCard={(c) => (
+              <VolunteerCard
+                card={c}
+                onClick={() => {
+                  setSelectedVolunteer(c);
+                  setVolunteerModalOpen(true);
+                }}
+                cutoffDateLabel={cutoffLabel}
+              />
+            )}
+            marginTop
+          />
+        </TabsContent>
+      </Tabs>
+
+      <IntakeDetailModal
+        card={selectedIntake}
+        open={intakeModalOpen}
+        onOpenChange={setIntakeModalOpen}
+        onUpdate={fetchAll}
+        roleOptions={roleOptions}
+        tempGroupRoleId={tempGroupRoleId}
+        cutoffDateLabel={cutoffLabel}
+      />
+      <VolunteerDetailModal
+        card={selectedVolunteer}
+        open={volunteerModalOpen}
+        onOpenChange={setVolunteerModalOpen}
+        onUpdate={fetchAll}
+        cutoffDateLabel={cutoffLabel}
+      />
+    </div>
+  );
+}

--- a/src/components/summer-blast-volunteers/volunteer-card.tsx
+++ b/src/components/summer-blast-volunteers/volunteer-card.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import React from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { PersonAvatar } from "@/components/processing";
+import { useRuntimeConfig } from "@/contexts";
+import { getDisplayName } from "@/lib/processing-utils";
+import { ChecklistStatusIcon } from "./checklist-icon";
+import { WillExpireBadge, WillExpireInlineBadge } from "./will-expire-badge";
+import type { SummerBlastVolunteerCard, SummerBlastChecklistItem } from "@/lib/dto";
+
+interface Props {
+  card: SummerBlastVolunteerCard;
+  onClick: () => void;
+  cutoffDateLabel?: string;
+}
+
+function statusBadge(card: SummerBlastVolunteerCard): { label: string; className: string } | null {
+  const hasMissing = card.checklist.some((c) => c.status === "not_started");
+  const hasExpired = card.checklist.some((c) => c.status === "expired");
+  if (hasMissing) return { label: "Missing", className: "bg-gray-100 text-gray-600" };
+  if (hasExpired) return { label: "Expired", className: "bg-red-100 text-red-700" };
+  if (card.hasWillExpire) return null;
+  if (card.isFullyCompliant) return { label: "Compliant", className: "bg-green-100 text-green-700" };
+  return null;
+}
+
+export function VolunteerCard({ card, onClick, cutoffDateLabel }: Props) {
+  const { mpFileUrl } = useRuntimeConfig();
+  const displayName = getDisplayName(card.info.First_Name, card.info.Nickname);
+  const badge = statusBadge(card);
+
+  return (
+    <Card
+      className="cursor-pointer hover:shadow-md transition-shadow py-4 gap-3 relative"
+      onClick={onClick}
+    >
+      <CardContent className="flex flex-col items-center px-3">
+        <div className="absolute top-2 right-2 flex items-center gap-1 z-10">
+          {badge && (
+            <span
+              className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${badge.className}`}
+            >
+              {badge.label}
+            </span>
+          )}
+          {card.hasWillExpire && <WillExpireBadge cutoffDate={cutoffDateLabel} />}
+        </div>
+
+        <div className="mb-2">
+          <PersonAvatar
+            imageGuid={card.info.Image_GUID}
+            mpFileUrl={mpFileUrl}
+            firstName={card.info.First_Name}
+            nickname={card.info.Nickname}
+            lastName={card.info.Last_Name}
+          />
+        </div>
+
+        <div className="text-sm font-medium text-center truncate w-full">
+          {displayName} {card.info.Last_Name}
+        </div>
+
+        <div className="text-xs text-muted-foreground mb-2">
+          {card.completedCount}/{card.totalCount} complete
+        </div>
+
+        <div className="w-full space-y-1">
+          {card.checklist.map((item) => (
+            <ChecklistRow key={item.key} item={item} />
+          ))}
+        </div>
+
+        {/* Role badge */}
+        <div className="flex flex-wrap gap-0.5 w-full mt-2 pt-2 border-t">
+          <span className="inline-flex items-center rounded-full bg-blue-50 px-1.5 py-0.5 text-[10px] font-medium text-blue-600">
+            {card.groupRoleLabel}
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ChecklistRow({ item }: { item: SummerBlastChecklistItem }) {
+  const textClass =
+    item.status === "complete"
+      ? "text-gray-700"
+      : item.status === "expired"
+        ? "text-red-500 line-through"
+        : item.status === "will_expire"
+          ? "text-amber-700"
+          : "text-gray-400";
+  return (
+    <div className="flex items-center gap-1.5">
+      <ChecklistStatusIcon status={item.status} />
+      <span className={`text-xs truncate ${textClass}`}>{item.label}</span>
+      {item.status === "will_expire" && <WillExpireInlineBadge />}
+    </div>
+  );
+}

--- a/src/components/summer-blast-volunteers/volunteer-detail-modal.tsx
+++ b/src/components/summer-blast-volunteers/volunteer-detail-modal.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { PersonAvatar, ContactLinks } from "@/components/processing";
+import { useRuntimeConfig } from "@/contexts";
+import { getDisplayName, formatDate } from "@/lib/processing-utils";
+import { ChecklistStatusIcon } from "./checklist-icon";
+import { WillExpireInlineBadge } from "./will-expire-badge";
+import {
+  createSummerBlastCpp,
+  createSummerBlastMandatedReporter,
+  removeFromSummerBlast,
+} from "./actions";
+import type {
+  SummerBlastVolunteerCard,
+  SummerBlastChecklistItem,
+} from "@/lib/dto";
+
+interface Props {
+  card: SummerBlastVolunteerCard | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onUpdate: () => void;
+  cutoffDateLabel?: string;
+}
+
+export function VolunteerDetailModal({
+  card,
+  open,
+  onOpenChange,
+  onUpdate,
+  cutoffDateLabel,
+}: Props) {
+  const { mpFileUrl } = useRuntimeConfig();
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [showRemoveConfirm, setShowRemoveConfirm] = useState(false);
+  const [cppDate, setCppDate] = useState(() => new Date().toISOString().split("T")[0]);
+  const [mrDate, setMrDate] = useState(() => new Date().toISOString().split("T")[0]);
+
+  React.useEffect(() => {
+    if (open) {
+      setError(null);
+      setActionLoading(null);
+      setShowRemoveConfirm(false);
+      setCppDate(new Date().toISOString().split("T")[0]);
+      setMrDate(new Date().toISOString().split("T")[0]);
+    }
+  }, [open]);
+
+  if (!card) return null;
+
+  const { info } = card;
+  const displayName = getDisplayName(info.First_Name, info.Nickname);
+  const hasCppRequirement = card.checklist.some((c) => c.type === "form");
+  const hasMrRequirement = card.checklist.some((c) => c.type === "certification");
+  const cppItem = card.checklist.find((c) => c.type === "form");
+  const mrItem = card.checklist.find((c) => c.type === "certification");
+
+  const handleAddCpp = async () => {
+    setActionLoading("cpp");
+    setError(null);
+    try {
+      const fd = new FormData();
+      fd.set("Contact_ID", String(info.Contact_ID));
+      fd.set("Response_Date", `${cppDate}T12:00:00`);
+      const result = await createSummerBlastCpp(fd);
+      if (!result.success) setError(result.error || "Failed");
+      else onUpdate();
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleAddMr = async () => {
+    setActionLoading("mr");
+    setError(null);
+    try {
+      const fd = new FormData();
+      fd.set("Participant_ID", String(info.Participant_ID));
+      fd.set("Certification_Completed", `${mrDate}T12:00:00`);
+      const result = await createSummerBlastMandatedReporter(fd);
+      if (!result.success) setError(result.error || "Failed");
+      else onUpdate();
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleRemove = async () => {
+    setActionLoading("remove");
+    setError(null);
+    try {
+      const fd = new FormData();
+      fd.set("Group_Participant_ID", String(card.groupParticipantId));
+      const result = await removeFromSummerBlast(fd);
+      if (!result.success) {
+        setError(result.error || "Failed to remove");
+      } else {
+        onUpdate();
+        onOpenChange(false);
+      }
+    } finally {
+      setActionLoading(null);
+      setShowRemoveConfirm(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[calc(100vw-1rem)] sm:max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <div className="flex items-center gap-4">
+            <PersonAvatar
+              imageGuid={info.Image_GUID}
+              mpFileUrl={mpFileUrl}
+              firstName={info.First_Name}
+              nickname={info.Nickname}
+              lastName={info.Last_Name}
+            />
+            <div>
+              <DialogTitle>
+                {displayName} {info.Last_Name}
+              </DialogTitle>
+              <DialogDescription>
+                Joined {formatDate(card.startDate)} — {card.groupRoleLabel}
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <ContactLinks
+          email={info.Email_Address}
+          phone={info.Mobile_Phone}
+          contactId={info.Contact_ID}
+        />
+
+        {error && (
+          <div className="text-sm text-red-600 bg-red-50 rounded-md p-2">{error}</div>
+        )}
+
+        {/* Requirements */}
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold">Requirements for {card.groupRoleLabel}</h3>
+          <div className="space-y-1">
+            {card.checklist.map((item) => (
+              <ChecklistRow key={item.key} item={item} />
+            ))}
+          </div>
+        </div>
+
+        {/* Add CPP */}
+        {hasCppRequirement && (
+          <div className="rounded-md border bg-gray-50 p-3 space-y-2">
+            <div className="flex items-center justify-between">
+              <h4 className="text-sm font-semibold">Add CPP (Child Protection Policy)</h4>
+              {cppItem?.status === "complete" && (
+                <span className="text-xs text-green-700">Current</span>
+              )}
+            </div>
+            <div className="flex flex-wrap items-end gap-2">
+              <div className="flex-1 min-w-[160px]">
+                <Label htmlFor="vol-cpp-date" className="text-xs">
+                  Response Date
+                </Label>
+                <input
+                  id="vol-cpp-date"
+                  type="date"
+                  value={cppDate}
+                  onChange={(e) => setCppDate(e.target.value)}
+                  className="mt-1 w-full rounded-md border bg-white px-2 py-1.5 text-sm"
+                />
+              </div>
+              <Button
+                size="sm"
+                onClick={handleAddCpp}
+                disabled={actionLoading !== null}
+                className="bg-blue-600 hover:bg-blue-700 text-white"
+              >
+                {actionLoading === "cpp" ? "Saving..." : "Add CPP"}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Add Mandated Reporter */}
+        {hasMrRequirement && (
+          <div className="rounded-md border bg-gray-50 p-3 space-y-2">
+            <div className="flex items-center justify-between">
+              <h4 className="text-sm font-semibold">Add Mandated Reporter Certification</h4>
+              {mrItem?.status === "complete" && (
+                <span className="text-xs text-green-700">Current</span>
+              )}
+            </div>
+            <div className="flex flex-wrap items-end gap-2">
+              <div className="flex-1 min-w-[160px]">
+                <Label htmlFor="vol-mr-date" className="text-xs">
+                  Completion Date
+                </Label>
+                <input
+                  id="vol-mr-date"
+                  type="date"
+                  value={mrDate}
+                  onChange={(e) => setMrDate(e.target.value)}
+                  className="mt-1 w-full rounded-md border bg-white px-2 py-1.5 text-sm"
+                />
+              </div>
+              <Button
+                size="sm"
+                onClick={handleAddMr}
+                disabled={actionLoading !== null}
+                className="bg-blue-600 hover:bg-blue-700 text-white"
+              >
+                {actionLoading === "mr" ? "Saving..." : "Add Mandated Reporter"}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Remove from group */}
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 space-y-2">
+          <h4 className="text-sm font-semibold text-red-800">Remove from Summer Blast</h4>
+          {!showRemoveConfirm ? (
+            <Button
+              size="sm"
+              variant="outline"
+              className="border-red-300 text-red-700 hover:bg-red-100"
+              onClick={() => setShowRemoveConfirm(true)}
+              disabled={actionLoading !== null}
+            >
+              Remove from Group
+            </Button>
+          ) : (
+            <div className="space-y-2">
+              <p className="text-xs text-red-900">
+                This will end-date the volunteer&apos;s participation in the Summer Blast
+                Volunteers group. Their Opportunity Response will stay closed.
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setShowRemoveConfirm(false)}
+                  disabled={actionLoading !== null}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={handleRemove}
+                  disabled={actionLoading !== null}
+                  className="bg-red-600 hover:bg-red-700 text-white"
+                >
+                  {actionLoading === "remove" ? "Removing..." : "Confirm Remove"}
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {cutoffDateLabel && (
+          <p className="text-[11px] text-muted-foreground">
+            &ldquo;Will Expire&rdquo; means the requirement is currently valid but expires before{" "}
+            {cutoffDateLabel}.
+          </p>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ChecklistRow({ item }: { item: SummerBlastChecklistItem }) {
+  const textClass =
+    item.status === "complete"
+      ? "text-gray-700"
+      : item.status === "expired"
+        ? "text-red-500 line-through"
+        : item.status === "will_expire"
+          ? "text-amber-700"
+          : "text-gray-500";
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      <ChecklistStatusIcon status={item.status} />
+      <span className={textClass}>{item.label}</span>
+      {item.status === "will_expire" && <WillExpireInlineBadge />}
+      {item.expires && (
+        <span className="ml-auto text-[11px] text-muted-foreground">
+          Expires {formatDate(item.expires)}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/summer-blast-volunteers/will-expire-badge.tsx
+++ b/src/components/summer-blast-volunteers/will-expire-badge.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import React from "react";
+
+interface WillExpireBadgeProps {
+  /** Optional date string formatted like "Jul 31, 2026" — appended to title. */
+  cutoffDate?: string;
+}
+
+/** Top-right summary badge — distinct from compliance "Expiring" (30-day). */
+export function WillExpireBadge({ cutoffDate }: WillExpireBadgeProps) {
+  const title = cutoffDate ? `Expires before ${cutoffDate}` : "Expires before event end";
+  return (
+    <span
+      className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-800 ring-1 ring-inset ring-amber-300"
+      title={title}
+    >
+      Will Expire
+    </span>
+  );
+}
+
+/** Per-item indicator: small chip used inline with checklist items. */
+export function WillExpireInlineBadge() {
+  return (
+    <span className="inline-flex items-center rounded-sm bg-amber-50 px-1 py-0 text-[9px] font-medium text-amber-800">
+      will expire
+    </span>
+  );
+}

--- a/src/lib/authorization.ts
+++ b/src/lib/authorization.ts
@@ -12,6 +12,7 @@ export type StaticFeature =
   | "dashboard"
   | "contact-lookup"
   | "manage-members"
+  | "summer-blast-volunteers"
   | "admin";
 
 /** Dynamic features follow the pattern "journey:{slug}" or "compliance:{slug}" */
@@ -41,6 +42,11 @@ const DEFAULT_CONFIG: FeatureAccessConfig = {
   "manage-members": {
     label: "Manage Members",
     description: "View and manage church membership statuses",
+    allowedGroupIds: [],
+  },
+  "summer-blast-volunteers": {
+    label: "Summer Blast Volunteers",
+    description: "Manage signups and volunteers for the Summer Blast event",
     allowedGroupIds: [],
   },
 };
@@ -155,6 +161,7 @@ export function getAccessibleFeatures(userGroupIds: number[]): Feature[] {
     "dashboard",
     "contact-lookup",
     "manage-members",
+    "summer-blast-volunteers",
     "admin",
   ];
 

--- a/src/lib/cache-warming.ts
+++ b/src/lib/cache-warming.ts
@@ -20,6 +20,8 @@
  * | getCachedEngagementData     | src/components/dashboard/cached-data.ts           | 6h         | 24h   |
  * | getCachedGroupTypes         | src/services/dashboardService.ts                 | 24h        | 48h   |
  * | getCachedAllContacts        | src/components/contact-lookup/cached-contacts.ts  | 6h         | 24h   |
+ * | getCachedSummerBlastIntake  | src/components/summer-blast-volunteers/cached-data.ts | 6h     | 24h   |
+ * | getCachedSummerBlastVolunteers | src/components/summer-blast-volunteers/cached-data.ts | 6h | 24h |
  *
  * Note: getCachedGroupTypes is warmed indirectly — it's called internally
  * by DashboardService during getCachedDashboardData/getCachedFullRangeData.
@@ -32,6 +34,10 @@ import {
   getCachedEngagementData,
 } from '@/components/dashboard/cached-data';
 import { getCachedAllContacts } from '@/components/contact-lookup/cached-contacts';
+import {
+  getCachedSummerBlastIntake,
+  getCachedSummerBlastVolunteers,
+} from '@/components/summer-blast-volunteers/cached-data';
 
 interface WarmingResult {
   name: string;
@@ -116,6 +122,13 @@ export async function warmAllCaches(): Promise<WarmingResult[]> {
     // Contact search: all contacts dataset
     warmOne('getCachedAllContacts', () =>
       getCachedAllContacts()
+    ),
+    // Summer Blast: signups (Opportunity Responses) and volunteers (Group 1031)
+    warmOne('getCachedSummerBlastIntake', () =>
+      getCachedSummerBlastIntake()
+    ),
+    warmOne('getCachedSummerBlastVolunteers', () =>
+      getCachedSummerBlastVolunteers()
     ),
   ]);
 

--- a/src/lib/dto/index.ts
+++ b/src/lib/dto/index.ts
@@ -5,3 +5,4 @@ export * from './dashboard';
 export * from './journey-processing';
 export * from './members';
 export * from './processing-shared';
+export * from './summer-blast';

--- a/src/lib/dto/summer-blast.ts
+++ b/src/lib/dto/summer-blast.ts
@@ -1,0 +1,59 @@
+import { BasePersonInfo } from "./processing-shared";
+import { BackgroundCheckDetail } from "./compliance-processing";
+
+export interface SummerBlastPersonInfo extends BasePersonInfo {
+  Email_Address: string | null;
+  Mobile_Phone: string | null;
+}
+
+export type SummerBlastItemStatus =
+  | "complete"
+  | "will_expire"
+  | "expired"
+  | "in_progress"
+  | "not_started";
+
+export interface SummerBlastChecklistItem {
+  key: string;
+  label: string;
+  type: "background_check" | "certification" | "form";
+  /** True when the requirement is satisfied AND won't expire before eventEndDate. */
+  completed: boolean;
+  /** Submission/completion date. */
+  date: string | null;
+  /** Expiration date, if any. */
+  expires: string | null;
+  status: SummerBlastItemStatus;
+  /** Free-text detail (e.g. "Failed" for cert). */
+  detail: string | null;
+  order: number;
+  /** Underlying MP record id for linking. */
+  recordId: number | null;
+  /** Structured detail for background check items. */
+  bgCheckDetail: BackgroundCheckDetail | null;
+}
+
+interface SummerBlastBaseCard {
+  info: SummerBlastPersonInfo;
+  checklist: SummerBlastChecklistItem[];
+  completedCount: number;
+  totalCount: number;
+  /** All items satisfied AND none expire before event end. */
+  isFullyCompliant: boolean;
+  /** Any item is currently valid but will expire before event end. */
+  hasWillExpire: boolean;
+}
+
+export interface SummerBlastIntakeCard extends SummerBlastBaseCard {
+  /** Underlying Responses record ID — needed when marking the response Closed. */
+  responseId: number;
+  /** Display date of the original signup. */
+  responseDate: string;
+}
+
+export interface SummerBlastVolunteerCard extends SummerBlastBaseCard {
+  groupParticipantId: number;
+  groupRoleId: number;
+  groupRoleLabel: string;
+  startDate: string;
+}

--- a/src/lib/summer-blast-config.ts
+++ b/src/lib/summer-blast-config.ts
@@ -1,0 +1,95 @@
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SummerBlastRequirementConfig {
+  requirementId: number;
+  label: string;
+  type: "background_check" | "certification" | "form";
+  sortOrder: number;
+}
+
+export interface SummerBlastRoleConfig {
+  groupRoleId: number;
+  label: string;
+  requirements: SummerBlastRequirementConfig[];
+}
+
+export interface SummerBlastConfig {
+  eventName: string;
+  eventEndDate: string;
+  intakeOpportunityId: number;
+  trackingGroupId: number;
+  tempGroupRoleId: number;
+  cppFormId: number;
+  mandatedReporterCertId: number;
+  intakeRequirements: SummerBlastRequirementConfig[];
+  roleConfigs: SummerBlastRoleConfig[];
+}
+
+// ---------------------------------------------------------------------------
+// Zod schemas
+// ---------------------------------------------------------------------------
+
+const RequirementSchema = z.object({
+  requirementId: z.number().int().nonnegative(),
+  label: z.string().min(1).max(200),
+  type: z.enum(["background_check", "certification", "form"]),
+  sortOrder: z.number().int().min(0),
+});
+
+const RoleConfigSchema = z.object({
+  groupRoleId: z.number().int().positive(),
+  label: z.string().min(1).max(200),
+  requirements: z.array(RequirementSchema),
+});
+
+const SummerBlastConfigSchema = z.object({
+  eventName: z.string().min(1),
+  eventEndDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD"),
+  intakeOpportunityId: z.number().int().positive(),
+  trackingGroupId: z.number().int().positive(),
+  tempGroupRoleId: z.number().int().positive(),
+  cppFormId: z.number().int().positive(),
+  mandatedReporterCertId: z.number().int().positive(),
+  intakeRequirements: z.array(RequirementSchema),
+  roleConfigs: z.array(RoleConfigSchema),
+});
+
+// ---------------------------------------------------------------------------
+// I/O (server-only)
+// ---------------------------------------------------------------------------
+
+const CONFIG_PATH = join(process.cwd(), "data", "summer-blast-config.json");
+
+let cached: SummerBlastConfig | null = null;
+
+export function getSummerBlastConfig(): SummerBlastConfig {
+  if (cached) return cached;
+  if (!existsSync(CONFIG_PATH)) {
+    throw new Error(`Summer Blast config not found at ${CONFIG_PATH}`);
+  }
+  const raw = readFileSync(CONFIG_PATH, "utf-8");
+  const parsed = JSON.parse(raw);
+  cached = SummerBlastConfigSchema.parse(parsed);
+  return cached;
+}
+
+/** Resolve the requirements list for a given Group_Role_ID. Falls back to intakeRequirements. */
+export function getRequirementsForRole(
+  config: SummerBlastConfig,
+  groupRoleId: number,
+): SummerBlastRequirementConfig[] {
+  const role = config.roleConfigs.find((r) => r.groupRoleId === groupRoleId);
+  if (role && role.requirements.length > 0) return role.requirements;
+  return config.intakeRequirements;
+}
+
+/** Label for a given Group_Role_ID. Returns null if not configured. */
+export function getRoleLabel(config: SummerBlastConfig, groupRoleId: number): string | null {
+  return config.roleConfigs.find((r) => r.groupRoleId === groupRoleId)?.label ?? null;
+}

--- a/src/services/summerBlastService.test.ts
+++ b/src/services/summerBlastService.test.ts
@@ -1,0 +1,483 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SummerBlastService, getEventExpirationStatus } from "@/services/summerBlastService";
+
+// Mock the config loader so tests don't depend on the JSON file.
+vi.mock("@/lib/summer-blast-config", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/summer-blast-config")>(
+    "@/lib/summer-blast-config",
+  );
+  return {
+    ...actual,
+    getSummerBlastConfig: () => ({
+      eventName: "Summer Blast",
+      eventEndDate: "2026-07-31",
+      intakeOpportunityId: 85,
+      trackingGroupId: 1031,
+      tempGroupRoleId: 1,
+      cppFormId: 83,
+      mandatedReporterCertId: 10,
+      intakeRequirements: [
+        { requirementId: 0, label: "Background Check", type: "background_check" as const, sortOrder: 1 },
+        { requirementId: 83, label: "CPP", type: "form" as const, sortOrder: 2 },
+        { requirementId: 10, label: "Mandated Reporter", type: "certification" as const, sortOrder: 3 },
+      ],
+      roleConfigs: [
+        {
+          groupRoleId: 48,
+          label: "Summer Blast Volunteer - Nursery",
+          requirements: [
+            { requirementId: 0, label: "Background Check", type: "background_check" as const, sortOrder: 1 },
+            { requirementId: 83, label: "CPP", type: "form" as const, sortOrder: 2 },
+            { requirementId: 10, label: "Mandated Reporter", type: "certification" as const, sortOrder: 3 },
+          ],
+        },
+        {
+          groupRoleId: 42,
+          label: "Summer Blast Volunteer - Chow",
+          requirements: [
+            { requirementId: 83, label: "CPP", type: "form" as const, sortOrder: 1 },
+          ],
+        },
+      ],
+    }),
+  };
+});
+
+// Provide a controllable MPHelper mock.
+const mockGetTableRecords = vi.fn();
+const mockCreateTableRecords = vi.fn();
+const mockUpdateTableRecords = vi.fn();
+
+vi.mock("@/lib/providers/ministry-platform", () => ({
+  MPHelper: class {
+    getTableRecords = mockGetTableRecords;
+    createTableRecords = mockCreateTableRecords;
+    updateTableRecords = mockUpdateTableRecords;
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Reset the SummerBlastService singleton.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (SummerBlastService as any).instance = null;
+});
+
+describe("getEventExpirationStatus", () => {
+  const cutoff = new Date(2026, 6, 31); // 2026-07-31 local
+
+  it("returns complete for null expiration", () => {
+    expect(getEventExpirationStatus(null, cutoff, new Date(2026, 4, 1))).toBe("complete");
+  });
+
+  it("returns expired for past dates", () => {
+    expect(
+      getEventExpirationStatus("2026-01-15T00:00:00", cutoff, new Date(2026, 4, 1)),
+    ).toBe("expired");
+  });
+
+  it("returns will_expire when between now and cutoff", () => {
+    expect(
+      getEventExpirationStatus("2026-07-01T00:00:00", cutoff, new Date(2026, 4, 1)),
+    ).toBe("will_expire");
+  });
+
+  it("returns complete when expires on/after cutoff", () => {
+    expect(
+      getEventExpirationStatus("2026-08-15T00:00:00", cutoff, new Date(2026, 4, 1)),
+    ).toBe("complete");
+  });
+
+  it("treats expiring on the cutoff itself as complete (boundary)", () => {
+    // The function uses strict <, so 'expires equals cutoff' is NOT will_expire.
+    const sameDay = "2026-07-31T00:00:00";
+    expect(getEventExpirationStatus(sameDay, cutoff, new Date(2026, 4, 1))).toBe(
+      "complete",
+    );
+  });
+});
+
+describe("SummerBlastService.getIntakeCards", () => {
+  it("returns open responses with checklist using intake requirements", async () => {
+    mockGetTableRecords.mockImplementation((params: { table: string }) => {
+      if (params.table === "Responses") {
+        return Promise.resolve([
+          {
+            Response_ID: 9001,
+            Response_Date: "2026-05-01T10:00:00",
+            Opportunity_ID: 85,
+            Participant_ID: 1111,
+            Closed: false,
+          },
+        ]);
+      }
+      if (params.table === "Participants") {
+        return Promise.resolve([{ Participant_ID: 1111, Contact_ID: 2222 }]);
+      }
+      if (params.table === "Contacts") {
+        return Promise.resolve([
+          {
+            Contact_ID: 2222,
+            First_Name: "Sample",
+            Nickname: null,
+            Last_Name: "Person",
+            Image_GUID: null,
+            Email_Address: null,
+            Mobile_Phone: null,
+          },
+        ]);
+      }
+      // No bg checks / certs / form responses
+      return Promise.resolve([]);
+    });
+
+    const service = SummerBlastService.getInstance();
+    const cards = await service.getIntakeCards();
+    expect(cards).toHaveLength(1);
+    const card = cards[0];
+    expect(card.responseId).toBe(9001);
+    expect(card.info.Contact_ID).toBe(2222);
+    expect(card.checklist).toHaveLength(3);
+    // All three requirements should be not_started since no records exist.
+    expect(card.checklist.every((c) => c.status === "not_started")).toBe(true);
+    expect(card.completedCount).toBe(0);
+    expect(card.totalCount).toBe(3);
+    expect(card.isFullyCompliant).toBe(false);
+    expect(card.hasWillExpire).toBe(false);
+  });
+
+  it("flags will_expire when a form expires before cutoff", async () => {
+    // Use vi.setSystemTime so the service's internal `new Date()` is deterministic.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-13T12:00:00Z"));
+
+    mockGetTableRecords.mockImplementation((params: { table: string }) => {
+      if (params.table === "Responses") {
+        return Promise.resolve([
+          {
+            Response_ID: 9002,
+            Response_Date: "2026-04-01T10:00:00",
+            Opportunity_ID: 85,
+            Participant_ID: 2000,
+            Closed: false,
+          },
+        ]);
+      }
+      if (params.table === "Participants") {
+        return Promise.resolve([{ Participant_ID: 2000, Contact_ID: 3000 }]);
+      }
+      if (params.table === "Contacts") {
+        return Promise.resolve([
+          {
+            Contact_ID: 3000,
+            First_Name: "Will",
+            Nickname: null,
+            Last_Name: "Expirepre",
+            Image_GUID: null,
+            Email_Address: null,
+            Mobile_Phone: null,
+          },
+        ]);
+      }
+      if (params.table === "Form_Responses") {
+        return Promise.resolve([
+          {
+            Form_Response_ID: 700,
+            Form_ID: 83,
+            Contact_ID: 3000,
+            Response_Date: "2025-08-01T00:00:00",
+            // Expires after "today" (2026-05-13) but before cutoff (2026-07-31)
+            Expires: "2026-07-01T00:00:00",
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    try {
+      const service = SummerBlastService.getInstance();
+      const cards = await service.getIntakeCards();
+      expect(cards).toHaveLength(1);
+      const cpp = cards[0].checklist.find((c) => c.type === "form");
+      expect(cpp).toBeDefined();
+      expect(cpp!.status).toBe("will_expire");
+      expect(cards[0].hasWillExpire).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("dedupes responses by participant, keeping most recent", async () => {
+    mockGetTableRecords.mockImplementation((params: { table: string }) => {
+      if (params.table === "Responses") {
+        return Promise.resolve([
+          {
+            Response_ID: 10,
+            Response_Date: "2026-01-01T10:00:00",
+            Opportunity_ID: 85,
+            Participant_ID: 7,
+            Closed: false,
+          },
+          {
+            Response_ID: 11,
+            Response_Date: "2026-04-01T10:00:00",
+            Opportunity_ID: 85,
+            Participant_ID: 7,
+            Closed: false,
+          },
+        ]);
+      }
+      if (params.table === "Participants")
+        return Promise.resolve([{ Participant_ID: 7, Contact_ID: 9 }]);
+      if (params.table === "Contacts")
+        return Promise.resolve([
+          {
+            Contact_ID: 9,
+            First_Name: "Dup",
+            Nickname: null,
+            Last_Name: "Test",
+            Image_GUID: null,
+            Email_Address: null,
+            Mobile_Phone: null,
+          },
+        ]);
+      return Promise.resolve([]);
+    });
+
+    const service = SummerBlastService.getInstance();
+    const cards = await service.getIntakeCards();
+    expect(cards).toHaveLength(1);
+    expect(cards[0].responseId).toBe(11);
+  });
+});
+
+describe("SummerBlastService.getVolunteerCards", () => {
+  it("uses role-specific requirements", async () => {
+    mockGetTableRecords.mockImplementation((params: { table: string }) => {
+      if (params.table === "Group_Participants") {
+        return Promise.resolve([
+          {
+            Group_Participant_ID: 555,
+            Participant_ID: 100,
+            Group_ID: 1031,
+            // Chow — should only require CPP
+            Group_Role_ID: 42,
+            Start_Date: "2026-05-01T00:00:00",
+            End_Date: null,
+          },
+        ]);
+      }
+      if (params.table === "Participants")
+        return Promise.resolve([{ Participant_ID: 100, Contact_ID: 200 }]);
+      if (params.table === "Contacts")
+        return Promise.resolve([
+          {
+            Contact_ID: 200,
+            First_Name: "Chow",
+            Nickname: null,
+            Last_Name: "Volunteer",
+            Image_GUID: null,
+            Email_Address: null,
+            Mobile_Phone: null,
+          },
+        ]);
+      return Promise.resolve([]);
+    });
+
+    const service = SummerBlastService.getInstance();
+    const cards = await service.getVolunteerCards();
+    expect(cards).toHaveLength(1);
+    expect(cards[0].groupRoleId).toBe(42);
+    expect(cards[0].groupRoleLabel).toContain("Chow");
+    expect(cards[0].checklist).toHaveLength(1);
+    expect(cards[0].checklist[0].type).toBe("form");
+  });
+
+  it("falls back to intake requirements for Temp role (id 1)", async () => {
+    mockGetTableRecords.mockImplementation((params: { table: string }) => {
+      if (params.table === "Group_Participants") {
+        return Promise.resolve([
+          {
+            Group_Participant_ID: 556,
+            Participant_ID: 101,
+            Group_ID: 1031,
+            Group_Role_ID: 1,
+            Start_Date: "2026-05-01T00:00:00",
+            End_Date: null,
+          },
+        ]);
+      }
+      if (params.table === "Participants")
+        return Promise.resolve([{ Participant_ID: 101, Contact_ID: 201 }]);
+      if (params.table === "Contacts")
+        return Promise.resolve([
+          {
+            Contact_ID: 201,
+            First_Name: "Temp",
+            Nickname: null,
+            Last_Name: "Volunteer",
+            Image_GUID: null,
+            Email_Address: null,
+            Mobile_Phone: null,
+          },
+        ]);
+      return Promise.resolve([]);
+    });
+
+    const service = SummerBlastService.getInstance();
+    const cards = await service.getVolunteerCards();
+    expect(cards).toHaveLength(1);
+    // Intake requirements has 3 items (BG, CPP, MR)
+    expect(cards[0].checklist).toHaveLength(3);
+    expect(cards[0].groupRoleLabel).toMatch(/Group Role 1/);
+  });
+
+  it("excludes participants with non-null End_Date in the past", async () => {
+    // Service filters End_Date IS NULL OR End_Date >= now at the SQL level —
+    // the test just verifies the filter is in the call.
+    mockGetTableRecords.mockImplementation((params: { table: string; filter?: string }) => {
+      if (params.table === "Group_Participants") {
+        expect(params.filter).toContain("End_Date IS NULL OR End_Date >=");
+        return Promise.resolve([]);
+      }
+      return Promise.resolve([]);
+    });
+    const service = SummerBlastService.getInstance();
+    const cards = await service.getVolunteerCards();
+    expect(cards).toEqual([]);
+  });
+});
+
+describe("SummerBlastService.addToSummerBlast", () => {
+  it("creates Group_Participants and closes the Response", async () => {
+    mockGetTableRecords.mockImplementation((params: { table: string }) => {
+      if (params.table === "Participants") {
+        return Promise.resolve([{ Participant_ID: 50, Contact_ID: 99 }]);
+      }
+      return Promise.resolve([]);
+    });
+    mockCreateTableRecords.mockResolvedValueOnce([{ Group_Participant_ID: 1234 }]);
+    mockUpdateTableRecords.mockResolvedValueOnce(undefined);
+
+    const service = SummerBlastService.getInstance();
+    const result = await service.addToSummerBlast({
+      contactId: 99,
+      responseId: 444,
+      groupRoleId: 48,
+    });
+    expect(result.groupParticipantId).toBe(1234);
+
+    expect(mockCreateTableRecords).toHaveBeenCalledWith(
+      "Group_Participants",
+      [
+        expect.objectContaining({
+          Group_ID: 1031,
+          Participant_ID: 50,
+          Group_Role_ID: 48,
+        }),
+      ],
+      expect.any(Object),
+    );
+    expect(mockUpdateTableRecords).toHaveBeenCalledWith(
+      "Responses",
+      [{ Response_ID: 444, Closed: true }],
+      expect.any(Object),
+    );
+  });
+
+  it("falls back to tempGroupRoleId when no role provided", async () => {
+    mockGetTableRecords.mockImplementation((params: { table: string }) => {
+      if (params.table === "Participants") {
+        return Promise.resolve([{ Participant_ID: 60, Contact_ID: 100 }]);
+      }
+      return Promise.resolve([]);
+    });
+    mockCreateTableRecords.mockResolvedValueOnce([{ Group_Participant_ID: 9 }]);
+    mockUpdateTableRecords.mockResolvedValueOnce(undefined);
+
+    const service = SummerBlastService.getInstance();
+    await service.addToSummerBlast({
+      contactId: 100,
+      responseId: 555,
+      groupRoleId: null,
+    });
+    expect(mockCreateTableRecords).toHaveBeenCalledWith(
+      "Group_Participants",
+      [expect.objectContaining({ Group_Role_ID: 1 })],
+      expect.any(Object),
+    );
+  });
+
+  it("throws if Contact has no Participant", async () => {
+    mockGetTableRecords.mockResolvedValueOnce([]);
+    const service = SummerBlastService.getInstance();
+    await expect(
+      service.addToSummerBlast({ contactId: 999, responseId: 1, groupRoleId: 42 }),
+    ).rejects.toThrow(/No Participant record/);
+  });
+});
+
+describe("SummerBlastService.removeFromSummerBlast", () => {
+  it("sets End_Date and does NOT update Responses", async () => {
+    mockUpdateTableRecords.mockResolvedValueOnce(undefined);
+    const service = SummerBlastService.getInstance();
+    await service.removeFromSummerBlast({ groupParticipantId: 888 });
+
+    expect(mockUpdateTableRecords).toHaveBeenCalledTimes(1);
+    expect(mockUpdateTableRecords).toHaveBeenCalledWith(
+      "Group_Participants",
+      [expect.objectContaining({ Group_Participant_ID: 888 })],
+      expect.any(Object),
+    );
+    // Confirm no Responses write occurred
+    const responseUpdates = mockUpdateTableRecords.mock.calls.filter(
+      (call) => call[0] === "Responses",
+    );
+    expect(responseUpdates).toHaveLength(0);
+  });
+});
+
+describe("SummerBlastService.createCpp / createMandatedReporter", () => {
+  it("creates a Form_Response with the configured CPP form id", async () => {
+    mockCreateTableRecords.mockResolvedValueOnce([{ Form_Response_ID: 17 }]);
+    const service = SummerBlastService.getInstance();
+    const id = await service.createCpp({
+      contactId: 5,
+      responseDate: "2026-05-13T12:00:00",
+    });
+    expect(id).toBe(17);
+    expect(mockCreateTableRecords).toHaveBeenCalledWith(
+      "Form_Responses",
+      [
+        expect.objectContaining({
+          Form_ID: 83,
+          Contact_ID: 5,
+          Response_Date: "2026-05-13T12:00:00",
+        }),
+      ],
+      expect.any(Object),
+    );
+  });
+
+  it("creates a Participant_Certification with the configured MR cert id", async () => {
+    mockCreateTableRecords.mockResolvedValueOnce([
+      { Participant_Certification_ID: 21 },
+    ]);
+    const service = SummerBlastService.getInstance();
+    const id = await service.createMandatedReporter({
+      participantId: 6,
+      completedDate: "2026-05-13T12:00:00",
+    });
+    expect(id).toBe(21);
+    expect(mockCreateTableRecords).toHaveBeenCalledWith(
+      "Participant_Certifications",
+      [
+        expect.objectContaining({
+          Participant_ID: 6,
+          Certification_Type_ID: 10,
+        }),
+      ],
+      expect.any(Object),
+    );
+  });
+});

--- a/src/services/summerBlastService.ts
+++ b/src/services/summerBlastService.ts
@@ -1,0 +1,686 @@
+import { MPHelper } from "@/lib/providers/ministry-platform";
+import { sanitizeIds } from "@/lib/providers/ministry-platform/utils/filter-sanitize";
+import { nowCentral } from "@/lib/processing-utils";
+import {
+  getSummerBlastConfig,
+  getRequirementsForRole,
+  getRoleLabel,
+  type SummerBlastConfig,
+  type SummerBlastRequirementConfig,
+} from "@/lib/summer-blast-config";
+import type {
+  SummerBlastIntakeCard,
+  SummerBlastVolunteerCard,
+  SummerBlastChecklistItem,
+  SummerBlastItemStatus,
+  SummerBlastPersonInfo,
+  BackgroundCheckDetail,
+} from "@/lib/dto";
+
+const BATCH_SIZE = 100;
+
+// ---------------------------------------------------------------------------
+// Status helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Status for an item given an event-end cutoff (e.g. 2026-07-31).
+ *
+ * - `null` expires (never expires) → `complete`
+ * - already past → `expired`
+ * - expires before cutoff → `will_expire`
+ * - expires on/after cutoff → `complete`
+ *
+ * Exported for unit testing.
+ */
+export function getEventExpirationStatus(
+  expiresDateStr: string | null,
+  cutoffDate: Date,
+  now: Date = new Date(),
+): "complete" | "expired" | "will_expire" {
+  if (!expiresDateStr) return "complete";
+  const expires = new Date(expiresDateStr);
+  if (expires < now) return "expired";
+  if (expires < cutoffDate) return "will_expire";
+  return "complete";
+}
+
+// ---------------------------------------------------------------------------
+// Raw record types
+// ---------------------------------------------------------------------------
+
+interface ResponseRecord {
+  Response_ID: number;
+  Response_Date: string;
+  Opportunity_ID: number;
+  Participant_ID: number;
+  Closed: boolean;
+}
+
+interface GroupParticipantRecord {
+  Group_Participant_ID: number;
+  Participant_ID: number;
+  Group_ID: number;
+  Group_Role_ID: number;
+  Start_Date: string;
+  End_Date: string | null;
+}
+
+interface ParticipantRecord {
+  Participant_ID: number;
+  Contact_ID: number;
+}
+
+interface ContactRecord {
+  Contact_ID: number;
+  First_Name: string;
+  Nickname: string | null;
+  Last_Name: string;
+  Image_GUID: string | null;
+  Email_Address: string | null;
+  Mobile_Phone: string | null;
+}
+
+interface BackgroundCheckRecord {
+  Background_Check_ID: number;
+  Contact_ID: number;
+  Background_Check_Status_ID: number | null;
+  Background_Check_Started: string;
+  Background_Check_Submitted: string | null;
+  Background_Check_Returned: string | null;
+  All_Clear: boolean | null;
+  Background_Check_Expires: string | null;
+  Report_Url: string | null;
+  Background_Check_Type_ID: number | null;
+}
+
+interface CertificationRecord {
+  Participant_Certification_ID: number;
+  Participant_ID: number;
+  Certification_Type_ID: number;
+  Certification_Completed: string | null;
+  Certification_Expires: string | null;
+  Passed: boolean | null;
+}
+
+interface FormResponseRecord {
+  Form_Response_ID: number;
+  Form_ID: number;
+  Contact_ID: number;
+  Response_Date: string;
+  Expires: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class SummerBlastService {
+  private static instance: SummerBlastService | null = null;
+  private mp: MPHelper;
+  private config: SummerBlastConfig;
+
+  private constructor(mp?: MPHelper) {
+    this.mp = mp ?? new MPHelper();
+    this.config = getSummerBlastConfig();
+  }
+
+  public static getInstance(): SummerBlastService {
+    if (!this.instance) this.instance = new SummerBlastService();
+    return this.instance;
+  }
+
+  /** Test-only constructor that accepts an injected MP helper. */
+  public static _createForTest(mp: MPHelper): SummerBlastService {
+    return new SummerBlastService(mp);
+  }
+
+  public getConfig(): SummerBlastConfig {
+    return this.config;
+  }
+
+  private getCutoffDate(): Date {
+    // eventEndDate is "YYYY-MM-DD" in Central time. Parse as local-noon so DST
+    // shifts don't move it across the date boundary.
+    const [y, m, d] = this.config.eventEndDate.split("-").map(Number);
+    return new Date(y, m - 1, d);
+  }
+
+  // -------------------------------------------------------------------------
+  // Tab 1: Intake (Opportunity Responses)
+  // -------------------------------------------------------------------------
+
+  public async getIntakeCards(): Promise<SummerBlastIntakeCard[]> {
+    const responses = await this.mp.getTableRecords<ResponseRecord>({
+      table: "Responses",
+      select: "Response_ID,Response_Date,Opportunity_ID,Participant_ID,Closed",
+      filter: `Opportunity_ID = ${this.config.intakeOpportunityId} AND Closed = 0`,
+      orderBy: "Response_Date DESC",
+    });
+
+    if (responses.length === 0) return [];
+
+    // Deduplicate by Participant_ID — keep the most recent open response per person.
+    const byParticipant = new Map<number, ResponseRecord>();
+    for (const r of responses) {
+      const existing = byParticipant.get(r.Participant_ID);
+      if (!existing || new Date(r.Response_Date) > new Date(existing.Response_Date)) {
+        byParticipant.set(r.Participant_ID, r);
+      }
+    }
+    const dedupedResponses = [...byParticipant.values()];
+    const participantIds = dedupedResponses.map((r) => r.Participant_ID);
+
+    const contacts = await this.getContactsForParticipants(participantIds);
+
+    const peopleByParticipant = new Map<number, SummerBlastPersonInfo>();
+    for (const r of dedupedResponses) {
+      const c = contacts.get(r.Participant_ID);
+      if (!c) continue;
+      peopleByParticipant.set(r.Participant_ID, {
+        Contact_ID: c.Contact_ID,
+        Participant_ID: r.Participant_ID,
+        First_Name: c.First_Name,
+        Nickname: c.Nickname,
+        Last_Name: c.Last_Name,
+        Image_GUID: c.Image_GUID,
+        Group_Participant_ID: null,
+        Start_Date: null,
+        Email_Address: c.Email_Address,
+        Mobile_Phone: c.Mobile_Phone,
+      });
+    }
+
+    if (peopleByParticipant.size === 0) return [];
+
+    const contactIds = [...peopleByParticipant.values()].map((p) => p.Contact_ID);
+    const allParticipantIds = [...peopleByParticipant.keys()];
+
+    const [bgChecks, certifications, formResponses] = await Promise.all([
+      this.fetchBackgroundChecks(contactIds),
+      this.fetchCertifications(allParticipantIds),
+      this.fetchFormResponses(contactIds),
+    ]);
+    const bgTypeNames = await this.fetchBgCheckTypeNames(bgChecks);
+    const cutoff = this.getCutoffDate();
+
+    const cards: SummerBlastIntakeCard[] = [];
+    for (const r of dedupedResponses) {
+      const info = peopleByParticipant.get(r.Participant_ID);
+      if (!info) continue;
+
+      const checklist = this.buildChecklist(
+        info.Contact_ID,
+        info.Participant_ID,
+        this.config.intakeRequirements,
+        bgChecks,
+        certifications,
+        formResponses,
+        bgTypeNames,
+        cutoff,
+      );
+
+      cards.push({
+        info,
+        checklist,
+        completedCount: checklist.filter((c) => c.status === "complete").length,
+        totalCount: checklist.length,
+        isFullyCompliant: checklist.every((c) => c.status === "complete"),
+        hasWillExpire: checklist.some((c) => c.status === "will_expire"),
+        responseId: r.Response_ID,
+        responseDate: r.Response_Date,
+      });
+    }
+
+    cards.sort((a, b) =>
+      a.info.Last_Name.localeCompare(b.info.Last_Name) ||
+      a.info.First_Name.localeCompare(b.info.First_Name),
+    );
+    return cards;
+  }
+
+  // -------------------------------------------------------------------------
+  // Tab 2: Volunteers (Group_Participants in tracking group)
+  // -------------------------------------------------------------------------
+
+  public async getVolunteerCards(): Promise<SummerBlastVolunteerCard[]> {
+    const now = nowCentral();
+    const gps = await this.mp.getTableRecords<GroupParticipantRecord>({
+      table: "Group_Participants",
+      select:
+        "Group_Participant_ID,Participant_ID,Group_ID,Group_Role_ID,Start_Date,End_Date",
+      filter: `Group_ID = ${this.config.trackingGroupId} AND (End_Date IS NULL OR End_Date >= '${now}')`,
+    });
+    if (gps.length === 0) return [];
+
+    // Deduplicate by Participant_ID — prefer record with null End_Date.
+    const byParticipant = new Map<number, GroupParticipantRecord>();
+    for (const gp of gps) {
+      const existing = byParticipant.get(gp.Participant_ID);
+      if (!existing || (gp.End_Date === null && existing.End_Date !== null)) {
+        byParticipant.set(gp.Participant_ID, gp);
+      }
+    }
+    const deduped = [...byParticipant.values()];
+    const participantIds = deduped.map((g) => g.Participant_ID);
+
+    const contacts = await this.getContactsForParticipants(participantIds);
+    if (contacts.size === 0) return [];
+
+    const contactIds = [...contacts.values()].map((c) => c.Contact_ID);
+
+    const [bgChecks, certifications, formResponses] = await Promise.all([
+      this.fetchBackgroundChecks(contactIds),
+      this.fetchCertifications(participantIds),
+      this.fetchFormResponses(contactIds),
+    ]);
+    const bgTypeNames = await this.fetchBgCheckTypeNames(bgChecks);
+    const cutoff = this.getCutoffDate();
+
+    const cards: SummerBlastVolunteerCard[] = [];
+    for (const gp of deduped) {
+      const c = contacts.get(gp.Participant_ID);
+      if (!c) continue;
+
+      const info: SummerBlastPersonInfo = {
+        Contact_ID: c.Contact_ID,
+        Participant_ID: gp.Participant_ID,
+        First_Name: c.First_Name,
+        Nickname: c.Nickname,
+        Last_Name: c.Last_Name,
+        Image_GUID: c.Image_GUID,
+        Group_Participant_ID: gp.Group_Participant_ID,
+        Start_Date: gp.Start_Date,
+        Email_Address: c.Email_Address,
+        Mobile_Phone: c.Mobile_Phone,
+      };
+
+      const requirements = getRequirementsForRole(this.config, gp.Group_Role_ID);
+      const checklist = this.buildChecklist(
+        info.Contact_ID,
+        info.Participant_ID,
+        requirements,
+        bgChecks,
+        certifications,
+        formResponses,
+        bgTypeNames,
+        cutoff,
+      );
+
+      cards.push({
+        info,
+        checklist,
+        completedCount: checklist.filter((i) => i.status === "complete").length,
+        totalCount: checklist.length,
+        isFullyCompliant: checklist.every((i) => i.status === "complete"),
+        hasWillExpire: checklist.some((i) => i.status === "will_expire"),
+        groupParticipantId: gp.Group_Participant_ID,
+        groupRoleId: gp.Group_Role_ID,
+        groupRoleLabel:
+          getRoleLabel(this.config, gp.Group_Role_ID) ?? `Group Role ${gp.Group_Role_ID}`,
+        startDate: gp.Start_Date,
+      });
+    }
+
+    cards.sort((a, b) =>
+      a.info.Last_Name.localeCompare(b.info.Last_Name) ||
+      a.info.First_Name.localeCompare(b.info.First_Name),
+    );
+    return cards;
+  }
+
+  // -------------------------------------------------------------------------
+  // Write actions
+  // -------------------------------------------------------------------------
+
+  /**
+   * Add a person to the Summer Blast tracking group AND mark their intake Response Closed.
+   * Both writes succeed or the second is attempted independently — we don't roll back the
+   * first since MP doesn't expose transactions. Order: create the participant first, then
+   * close the response, so a failure mid-way leaves a participant + an open response
+   * (a re-try just re-runs both, and the de-duplicating client will hide the duplicate
+   * once the participant exists for this person).
+   */
+  public async addToSummerBlast(params: {
+    contactId: number;
+    responseId: number;
+    groupRoleId: number | null;
+    userId?: number;
+  }): Promise<{ groupParticipantId: number }> {
+    const { contactId, responseId, groupRoleId, userId } = params;
+
+    // Resolve Contact_ID → Participant_ID.
+    const participants = await this.mp.getTableRecords<ParticipantRecord>({
+      table: "Participants",
+      select: "Participant_ID,Contact_ID",
+      filter: `Contact_ID = ${contactId}`,
+      top: 1,
+    });
+    if (participants.length === 0) {
+      throw new Error(`No Participant record for Contact_ID ${contactId}`);
+    }
+    const participantId = participants[0].Participant_ID;
+
+    const now = nowCentral();
+    const roleId = groupRoleId ?? this.config.tempGroupRoleId;
+
+    const created = (await this.mp.createTableRecords(
+      "Group_Participants",
+      [
+        {
+          Group_ID: this.config.trackingGroupId,
+          Participant_ID: participantId,
+          Group_Role_ID: roleId,
+          Start_Date: now,
+        },
+      ],
+      { $userId: userId },
+    )) as unknown as { Group_Participant_ID: number }[];
+
+    const groupParticipantId = created[0].Group_Participant_ID;
+
+    // Close the response so it disappears from the intake tab.
+    await this.mp.updateTableRecords(
+      "Responses",
+      [{ Response_ID: responseId, Closed: true }],
+      { $userId: userId },
+    );
+
+    return { groupParticipantId };
+  }
+
+  /** End-date a Group_Participants row (does not touch Responses). */
+  public async removeFromSummerBlast(params: {
+    groupParticipantId: number;
+    userId?: number;
+  }): Promise<void> {
+    const { groupParticipantId, userId } = params;
+    const now = nowCentral();
+    await this.mp.updateTableRecords(
+      "Group_Participants",
+      [{ Group_Participant_ID: groupParticipantId, End_Date: now }],
+      { $userId: userId },
+    );
+  }
+
+  /** Create a CPP form response for a contact. */
+  public async createCpp(params: {
+    contactId: number;
+    responseDate: string;
+    userId?: number;
+  }): Promise<number> {
+    const { contactId, responseDate, userId } = params;
+    const created = (await this.mp.createTableRecords(
+      "Form_Responses",
+      [
+        {
+          Form_ID: this.config.cppFormId,
+          Contact_ID: contactId,
+          Response_Date: responseDate,
+        },
+      ],
+      { $userId: userId },
+    )) as unknown as { Form_Response_ID: number }[];
+    return created[0].Form_Response_ID;
+  }
+
+  /** Create a Mandated Reporter certification for a participant. */
+  public async createMandatedReporter(params: {
+    participantId: number;
+    completedDate: string;
+    userId?: number;
+  }): Promise<number> {
+    const { participantId, completedDate, userId } = params;
+    const created = (await this.mp.createTableRecords(
+      "Participant_Certifications",
+      [
+        {
+          Participant_ID: participantId,
+          Certification_Type_ID: this.config.mandatedReporterCertId,
+          Certification_Submitted: nowCentral(),
+          Certification_Completed: completedDate,
+        },
+      ],
+      { $userId: userId },
+    )) as unknown as { Participant_Certification_ID: number }[];
+    return created[0].Participant_Certification_ID;
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  private buildChecklist(
+    contactId: number,
+    participantId: number,
+    requirements: SummerBlastRequirementConfig[],
+    bgChecks: BackgroundCheckRecord[],
+    certifications: CertificationRecord[],
+    formResponses: FormResponseRecord[],
+    bgTypeNames: Map<number, string>,
+    cutoff: Date,
+  ): SummerBlastChecklistItem[] {
+    const items: SummerBlastChecklistItem[] = [];
+
+    for (const req of [...requirements].sort((a, b) => a.sortOrder - b.sortOrder)) {
+      switch (req.type) {
+        case "background_check": {
+          const latest = bgChecks.find((bc) => bc.Contact_ID === contactId);
+          const passed = latest?.All_Clear === true;
+          const expires = latest?.Background_Check_Expires ?? null;
+          const status: SummerBlastItemStatus = !passed
+            ? "not_started"
+            : getEventExpirationStatus(expires, cutoff);
+
+          let bgDetail: BackgroundCheckDetail | null = null;
+          if (latest) {
+            let bgStatus = "Pending";
+            if (latest.All_Clear === true && latest.Background_Check_Returned) bgStatus = "Completed";
+            else if (latest.Background_Check_Returned) bgStatus = "Returned";
+            else if (latest.Background_Check_Submitted) bgStatus = "Submitted";
+            else bgStatus = "Started";
+            bgDetail = {
+              typeName: latest.Background_Check_Type_ID
+                ? bgTypeNames.get(latest.Background_Check_Type_ID) ?? null
+                : null,
+              status: bgStatus,
+              started: latest.Background_Check_Started,
+              submitted: latest.Background_Check_Submitted,
+              returned: latest.Background_Check_Returned,
+              allClear: latest.All_Clear,
+              expires: latest.Background_Check_Expires,
+              reportUrl: latest.Report_Url,
+            };
+          }
+
+          items.push({
+            key: `req-${req.requirementId}-bg`,
+            label: req.label,
+            type: "background_check",
+            completed: status === "complete",
+            date:
+              latest?.Background_Check_Returned ??
+              latest?.Background_Check_Started ??
+              null,
+            expires,
+            status,
+            detail: latest ? (latest.All_Clear ? "All Clear" : "Pending") : null,
+            order: req.sortOrder,
+            recordId: latest?.Background_Check_ID ?? null,
+            bgCheckDetail: bgDetail,
+          });
+          break;
+        }
+        case "certification": {
+          const latest = certifications.find(
+            (c) =>
+              c.Participant_ID === participantId &&
+              c.Certification_Type_ID === req.requirementId,
+          );
+          const passed = !!latest?.Certification_Completed && latest.Passed !== false;
+          const expires = latest?.Certification_Expires ?? null;
+          const status: SummerBlastItemStatus = passed
+            ? getEventExpirationStatus(expires, cutoff)
+            : latest
+              ? "in_progress"
+              : "not_started";
+          items.push({
+            key: `req-${req.requirementId}-cert`,
+            label: req.label,
+            type: "certification",
+            completed: status === "complete",
+            date: latest?.Certification_Completed ?? null,
+            expires,
+            status,
+            detail: latest?.Passed === false ? "Failed" : null,
+            order: req.sortOrder,
+            recordId: latest?.Participant_Certification_ID ?? null,
+            bgCheckDetail: null,
+          });
+          break;
+        }
+        case "form": {
+          const latest = formResponses.find(
+            (f) => f.Contact_ID === contactId && f.Form_ID === req.requirementId,
+          );
+          const submitted = !!latest;
+          const expires = latest?.Expires ?? null;
+          const status: SummerBlastItemStatus = submitted
+            ? getEventExpirationStatus(expires, cutoff)
+            : "not_started";
+          items.push({
+            key: `req-${req.requirementId}-form`,
+            label: req.label,
+            type: "form",
+            completed: status === "complete",
+            date: latest?.Response_Date ?? null,
+            expires,
+            status,
+            detail: null,
+            order: req.sortOrder,
+            recordId: latest?.Form_Response_ID ?? null,
+            bgCheckDetail: null,
+          });
+          break;
+        }
+      }
+    }
+    return items.sort((a, b) => a.order - b.order);
+  }
+
+  private async getContactsForParticipants(
+    participantIds: number[],
+  ): Promise<Map<number, ContactRecord & { Participant_ID: number }>> {
+    if (participantIds.length === 0) return new Map();
+
+    const allParticipants: ParticipantRecord[] = [];
+    for (let i = 0; i < participantIds.length; i += BATCH_SIZE) {
+      const batchIds = participantIds.slice(i, i + BATCH_SIZE);
+      const batch = await this.mp.getTableRecords<ParticipantRecord>({
+        table: "Participants",
+        select: "Participant_ID,Contact_ID",
+        filter: `Participant_ID IN (${sanitizeIds(batchIds)})`,
+      });
+      allParticipants.push(...batch);
+    }
+
+    const contactIds = [...new Set(allParticipants.map((p) => p.Contact_ID))];
+    if (contactIds.length === 0) return new Map();
+
+    const allContacts: ContactRecord[] = [];
+    for (let i = 0; i < contactIds.length; i += BATCH_SIZE) {
+      const batchIds = contactIds.slice(i, i + BATCH_SIZE);
+      const batch = await this.mp.getTableRecords<ContactRecord>({
+        table: "Contacts",
+        select:
+          "Contact_ID,First_Name,Nickname,Last_Name,dp_fileUniqueId AS Image_GUID,Email_Address,Mobile_Phone",
+        filter: `Contact_ID IN (${sanitizeIds(batchIds)})`,
+      });
+      allContacts.push(...batch);
+    }
+
+    const contactMap = new Map(allContacts.map((c) => [c.Contact_ID, c]));
+    const result = new Map<number, ContactRecord & { Participant_ID: number }>();
+    for (const p of allParticipants) {
+      const c = contactMap.get(p.Contact_ID);
+      if (c) result.set(p.Participant_ID, { ...c, Participant_ID: p.Participant_ID });
+    }
+    return result;
+  }
+
+  private async fetchBackgroundChecks(contactIds: number[]): Promise<BackgroundCheckRecord[]> {
+    if (contactIds.length === 0) return [];
+    const all: BackgroundCheckRecord[] = [];
+    for (let i = 0; i < contactIds.length; i += BATCH_SIZE) {
+      const batchIds = contactIds.slice(i, i + BATCH_SIZE);
+      const batch = await this.mp.getTableRecords<BackgroundCheckRecord>({
+        table: "Background_Checks",
+        select:
+          "Background_Check_ID,Contact_ID,Background_Check_Status_ID,Background_Check_Started,Background_Check_Submitted,Background_Check_Returned,All_Clear,Background_Check_Expires,Report_Url,Background_Check_Type_ID",
+        filter: `Contact_ID IN (${sanitizeIds(batchIds)})`,
+        orderBy: "Background_Check_Started DESC",
+      });
+      all.push(...batch);
+    }
+    return all;
+  }
+
+  private async fetchBgCheckTypeNames(
+    bgChecks: BackgroundCheckRecord[],
+  ): Promise<Map<number, string>> {
+    const typeIds = [
+      ...new Set(
+        bgChecks
+          .map((b) => b.Background_Check_Type_ID)
+          .filter((id): id is number => id !== null),
+      ),
+    ];
+    if (typeIds.length === 0) return new Map();
+    const types = await this.mp.getTableRecords<{
+      Background_Check_Type_ID: number;
+      Background_Check_Type: string;
+    }>({
+      table: "Background_Check_Types",
+      select: "Background_Check_Type_ID,Background_Check_Type",
+      filter: `Background_Check_Type_ID IN (${sanitizeIds(typeIds)})`,
+    });
+    return new Map(types.map((t) => [t.Background_Check_Type_ID, t.Background_Check_Type]));
+  }
+
+  private async fetchCertifications(
+    participantIds: number[],
+  ): Promise<CertificationRecord[]> {
+    if (participantIds.length === 0) return [];
+    const all: CertificationRecord[] = [];
+    for (let i = 0; i < participantIds.length; i += BATCH_SIZE) {
+      const batchIds = participantIds.slice(i, i + BATCH_SIZE);
+      const batch = await this.mp.getTableRecords<CertificationRecord>({
+        table: "Participant_Certifications",
+        select:
+          "Participant_Certification_ID,Participant_ID,Certification_Type_ID,Certification_Completed,Certification_Expires,Passed",
+        filter: `Participant_ID IN (${sanitizeIds(batchIds)})`,
+        orderBy: "Certification_Completed DESC",
+      });
+      all.push(...batch);
+    }
+    return all;
+  }
+
+  private async fetchFormResponses(
+    contactIds: number[],
+  ): Promise<FormResponseRecord[]> {
+    if (contactIds.length === 0) return [];
+    const all: FormResponseRecord[] = [];
+    for (let i = 0; i < contactIds.length; i += BATCH_SIZE) {
+      const batchIds = contactIds.slice(i, i + BATCH_SIZE);
+      const batch = await this.mp.getTableRecords<FormResponseRecord>({
+        table: "Form_Responses",
+        select: "Form_Response_ID,Form_ID,Contact_ID,Response_Date,Expires",
+        filter: `Contact_ID IN (${sanitizeIds(batchIds)})`,
+        orderBy: "Response_Date DESC",
+      });
+      all.push(...batch);
+    }
+    return all;
+  }
+}


### PR DESCRIPTION
## Summary

- New `/summer-blast-volunteers` route with two tabs: **Signups** (open Opportunity 85 Responses) and **Volunteers** (active Group_Participants in Group 1031).
- Custom **Will Expire** badge (amber) for any requirement currently valid but expiring before **2026-07-31** (day after Summer Blast event 7/27–7/30).
- Tab 1 cards have inline CPP / Mandated Reporter quick-add and an "Added to SB Spreadsheet" button that creates the Group_Participant in Group 1031 (using chosen Group_Role_ID 42-52, or Temp role 1 if unchosen) AND marks the Response `Closed = true`.
- Tab 2 cards show role-specific requirements (config in `data/summer-blast-config.json`, with Temp role 1 + unmapped roles falling back to BG+CPP+MR). "Remove from group" end-dates the participant without reopening the Response.
- Cache-warmed alongside dashboard and contact-search caches; `'use cache'` + `serviceCache` safety net.

## Architecture

Bespoke route (not a generic compliance tool) — the data source for Tab 1 is `Responses`, not `Group_Participants`, which would have muddied the existing compliance abstraction. Cards/icons reuse the same visual language as `compliance-card.tsx`, but the underlying expiration logic uses an event cutoff instead of a 30-day rolling window. New static feature `summer-blast-volunteers` registered in `authorization.ts`.

## Files created

- `data/summer-blast-config.json` — Event date, opportunity, tracking group, temp role, form/cert IDs, intake requirements, per-role requirements (42-52).
- `src/lib/summer-blast-config.ts` — Zod-validated loader.
- `src/lib/dto/summer-blast.ts` — Card / checklist DTOs.
- `src/services/summerBlastService.ts` + `.test.ts` — 17 unit tests (event-cutoff logic, intake / volunteer card building, role-specific requirements, Temp fallback, add/remove behavior, write call shapes).
- `src/app/(web)/summer-blast-volunteers/page.tsx`
- `src/components/summer-blast-volunteers/*` — main client component (Tabs), cards, modals, badges, server actions, cached data.

## Files modified

- `src/lib/authorization.ts` — Added `summer-blast-volunteers` as a `StaticFeature`.
- `src/lib/cache-warming.ts` — Registered two new cached functions.
- `src/lib/dto/index.ts` — Barrel export.
- `src/components/layout/sidebar.tsx` — New nav entry (SunIcon).
- `src/components/home/home-cards.tsx` — New home card.

## Security Review

- All MP filters use literal integers (Opportunity_ID, Group_ID) or pass through `sanitizeIds()`. No user-input interpolation in filters.
- All server actions call `requireFeatureAccess("summer-blast-volunteers")` and `enforceRateLimit(userId, "write")` for mutations.
- No PII logging.
- New feature gated via `data/feature-access.json` (allowedGroupIds: 29, 32 by default — mirrors `compliance:active-teachers-and-volunteers`; adjust on the server if SB team uses different groups).
- File uploads: not applicable (no upload paths in this feature).
- Redirects: not applicable.

## Test plan

- [ ] On dev, navigate to `/summer-blast-volunteers`. Confirm sidebar + home card show for an authorized user.
- [ ] Tab 1 lists at least one open Opportunity 85 response. Click a card; modal opens.
- [ ] Add a CPP form response from the modal; verify the row in `Form_Responses` and that the card's CPP checklist line goes green.
- [ ] Add a Mandated Reporter cert from the modal; verify the row in `Participant_Certifications`.
- [ ] Click "Added to SB Spreadsheet" with role "Nursery" (48); verify:
  - New `Group_Participants` row (Group_ID=1031, Group_Role_ID=48, End_Date=null).
  - `Responses` row updated to `Closed=true`.
  - Card disappears from Tab 1, appears on Tab 2.
- [ ] Repeat with no role chosen; verify Group_Role_ID=1 (Temp).
- [ ] On Tab 2, click a Temp volunteer's card; confirm checklist shows BG+CPP+MR (intake fallback).
- [ ] On Tab 2, click a Nursery volunteer's card; confirm checklist shows BG+CPP+MR.
- [ ] On Tab 2, click a Chow volunteer's card; confirm checklist shows only CPP.
- [ ] Click "Remove from group"; confirm `Group_Participants.End_Date` is set to now AND the Response stays Closed.
- [ ] Verify "Will Expire" badge appears on a card where any requirement has `Expires` between today and 2026-07-31.

## Follow-ups (post-merge if needed)

1. **Per-role requirements matrix** — currently kid-facing roles (44, 45, 46, 47, 48, 51) get BG+CPP+MR; logistics roles (42, 43, 49, 50, 52) get CPP only. Adjust if Registration/Prayer Team should also need BG.
2. **`feature-access.json` `allowedGroupIds`** — mirrors `compliance:active-teachers-and-volunteers` (29, 32). Adjust on the server if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)