### PR TITLE
feat(summer-blast): age + Youth pill + Group 964 membership requirement

### DIFF
--- a/data/summer-blast-config.json
+++ b/data/summer-blast-config.json
@@ -6,6 +6,8 @@
   "tempGroupRoleId": 1,
   "cppFormId": 83,
   "mandatedReporterCertId": 10,
+  "youthGroupId": 964,
+  "youthRequirementLabel": "Youth Assistant Form (Group 964)",
   "intakeRequirements": [
     {
       "requirementId": 0,

--- a/src/components/summer-blast-volunteers/intake-card.tsx
+++ b/src/components/summer-blast-volunteers/intake-card.tsx
@@ -36,6 +36,15 @@ export function IntakeCard({ card, onClick, cutoffDateLabel }: Props) {
       onClick={onClick}
     >
       <CardContent className="flex flex-col items-center px-3">
+        {/* Youth pill (top-left) — only for under-18 signups */}
+        {card.age !== null && card.age < 18 && (
+          <div className="absolute top-2 left-2 z-10">
+            <span className="inline-flex items-center rounded-full bg-indigo-100 px-2 py-0.5 text-[10px] font-medium text-indigo-700 ring-1 ring-inset ring-indigo-300">
+              Youth
+            </span>
+          </div>
+        )}
+
         {/* Status badges (top-right) */}
         <div className="absolute top-2 right-2 flex items-center gap-1 z-10">
           {badge && (
@@ -63,6 +72,10 @@ export function IntakeCard({ card, onClick, cutoffDateLabel }: Props) {
         <div className="text-sm font-medium text-center truncate w-full">
           {displayName} {card.info.Last_Name}
         </div>
+
+        {card.age !== null && (
+          <div className="text-[11px] text-muted-foreground">Age {card.age}</div>
+        )}
 
         {/* Signed-up date */}
         <div className="text-[11px] text-muted-foreground">

--- a/src/components/summer-blast-volunteers/volunteer-card.tsx
+++ b/src/components/summer-blast-volunteers/volunteer-card.tsx
@@ -36,6 +36,15 @@ export function VolunteerCard({ card, onClick, cutoffDateLabel }: Props) {
       onClick={onClick}
     >
       <CardContent className="flex flex-col items-center px-3">
+        {/* Youth pill (top-left) — only for under-18 volunteers */}
+        {card.age !== null && card.age < 18 && (
+          <div className="absolute top-2 left-2 z-10">
+            <span className="inline-flex items-center rounded-full bg-indigo-100 px-2 py-0.5 text-[10px] font-medium text-indigo-700 ring-1 ring-inset ring-indigo-300">
+              Youth
+            </span>
+          </div>
+        )}
+
         <div className="absolute top-2 right-2 flex items-center gap-1 z-10">
           {badge && (
             <span
@@ -60,6 +69,10 @@ export function VolunteerCard({ card, onClick, cutoffDateLabel }: Props) {
         <div className="text-sm font-medium text-center truncate w-full">
           {displayName} {card.info.Last_Name}
         </div>
+
+        {card.age !== null && (
+          <div className="text-[11px] text-muted-foreground">Age {card.age}</div>
+        )}
 
         <div className="text-xs text-muted-foreground mb-2">
           {card.completedCount}/{card.totalCount} complete

--- a/src/lib/dto/summer-blast.ts
+++ b/src/lib/dto/summer-blast.ts
@@ -16,7 +16,7 @@ export type SummerBlastItemStatus =
 export interface SummerBlastChecklistItem {
   key: string;
   label: string;
-  type: "background_check" | "certification" | "form";
+  type: "background_check" | "certification" | "form" | "group_membership";
   /** True when the requirement is satisfied AND won't expire before eventEndDate. */
   completed: boolean;
   /** Submission/completion date. */
@@ -42,6 +42,8 @@ interface SummerBlastBaseCard {
   isFullyCompliant: boolean;
   /** Any item is currently valid but will expire before event end. */
   hasWillExpire: boolean;
+  /** Volunteer's age in years (computed from Date_of_Birth). Null when DOB is unknown. */
+  age: number | null;
 }
 
 export interface SummerBlastIntakeCard extends SummerBlastBaseCard {

--- a/src/lib/processing-utils.test.ts
+++ b/src/lib/processing-utils.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   searchByName, searchByNameFlat, filterByName,
   soundex, soundexMatch, levenshtein, normalizeApostrophes,
   getDisplayName, getInitials, getImageUrl, formatDate, nowCentral,
-  scoreNameMatch,
+  scoreNameMatch, getAge,
   ALLOWED_IMAGE_TYPES, ALLOWED_DOCUMENT_TYPES, MAX_FILE_SIZE,
 } from "./processing-utils";
 
@@ -535,5 +535,67 @@ describe("constants", () => {
 
   it("MAX_FILE_SIZE is 20 MB", () => {
     expect(MAX_FILE_SIZE).toBe(20 * 1024 * 1024);
+  });
+});
+
+describe("getAge", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function setNow(iso: string) {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(iso));
+  }
+
+  it("returns null for null", () => {
+    expect(getAge(null)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(getAge("")).toBeNull();
+  });
+
+  it("returns null for invalid date string", () => {
+    expect(getAge("not-a-date")).toBeNull();
+  });
+
+  it("returns null when DOB is in the future", () => {
+    setNow("2026-05-13T12:00:00Z");
+    expect(getAge("2030-01-01")).toBeNull();
+  });
+
+  it("returns integer age when birthday has already passed this year", () => {
+    setNow("2026-05-13T12:00:00Z");
+    // Born March 1, 2010 — birthday already passed → 16
+    expect(getAge("2010-03-01")).toBe(16);
+  });
+
+  it("returns one less when birthday has NOT happened yet this year", () => {
+    setNow("2026-05-13T12:00:00Z");
+    // Born November 30, 2010 — birthday not yet this year → 15
+    expect(getAge("2010-11-30")).toBe(15);
+  });
+
+  it("returns exact age on the birthday itself", () => {
+    setNow("2026-05-13T12:00:00Z");
+    // Born May 13, 2008 — turning 18 today
+    expect(getAge("2008-05-13")).toBe(18);
+  });
+
+  it("returns one less the day before birthday", () => {
+    setNow("2026-05-13T12:00:00Z");
+    // Born May 14, 2008 — birthday is tomorrow → still 17
+    expect(getAge("2008-05-14")).toBe(17);
+  });
+
+  it("handles older adults", () => {
+    setNow("2026-05-13T12:00:00Z");
+    expect(getAge("1930-01-01")).toBe(96);
+  });
+
+  it("handles infants (age 0)", () => {
+    setNow("2026-05-13T12:00:00Z");
+    expect(getAge("2026-01-15")).toBe(0);
   });
 });

--- a/src/lib/processing-utils.ts
+++ b/src/lib/processing-utils.ts
@@ -102,6 +102,30 @@ export function nowCentral(): string {
   return `${get('year')}-${get('month')}-${get('day')}T${get('hour')}:${get('minute')}:${get('second')}`;
 }
 
+/**
+ * Compute integer age in years from a Date_of_Birth string.
+ * Accepts "YYYY-MM-DD" or "YYYY-MM-DDTHH:MM:SS" (MP's naive-Central format).
+ * The date portion is parsed as a LOCAL date so we never lose a day to the
+ * UTC-midnight gotcha in negative-offset zones.
+ * Returns null when the input is null/blank/invalid or in the future.
+ */
+export function getAge(dobStr: string | null): number | null {
+  if (!dobStr) return null;
+  const parts = dobStr.slice(0, 10).split("-").map(Number);
+  if (parts.length !== 3 || parts.some((n) => !Number.isFinite(n))) return null;
+  const [y, m, d] = parts;
+  const dob = new Date(y, m - 1, d);
+  if (Number.isNaN(dob.getTime())) return null;
+  const now = new Date();
+  if (dob > now) return null;
+  let age = now.getFullYear() - dob.getFullYear();
+  const hadBirthdayThisYear =
+    now.getMonth() > dob.getMonth() ||
+    (now.getMonth() === dob.getMonth() && now.getDate() >= dob.getDate());
+  if (!hadBirthdayThisYear) age -= 1;
+  return age;
+}
+
 /** Normalize apostrophe variants (curly quotes, modifier letter) to ASCII and strip them for comparison. */
 export function normalizeApostrophes(s: string): string {
   return s.replace(/[\u2018\u2019\u02BC']/g, "");

--- a/src/lib/summer-blast-config.ts
+++ b/src/lib/summer-blast-config.ts
@@ -27,6 +27,10 @@ export interface SummerBlastConfig {
   tempGroupRoleId: number;
   cppFormId: number;
   mandatedReporterCertId: number;
+  /** Group_ID for "Youth Assistant" — active membership = youth assistant form complete. */
+  youthGroupId: number;
+  /** Label used on the single checklist item shown to under-18 volunteers. */
+  youthRequirementLabel: string;
   intakeRequirements: SummerBlastRequirementConfig[];
   roleConfigs: SummerBlastRoleConfig[];
 }
@@ -56,6 +60,8 @@ const SummerBlastConfigSchema = z.object({
   tempGroupRoleId: z.number().int().positive(),
   cppFormId: z.number().int().positive(),
   mandatedReporterCertId: z.number().int().positive(),
+  youthGroupId: z.number().int().positive(),
+  youthRequirementLabel: z.string().min(1).max(200),
   intakeRequirements: z.array(RequirementSchema),
   roleConfigs: z.array(RoleConfigSchema),
 });

--- a/src/services/summerBlastService.test.ts
+++ b/src/services/summerBlastService.test.ts
@@ -20,6 +20,8 @@ vi.mock("@/lib/summer-blast-config", async () => {
       tempGroupRoleId: 1,
       cppFormId: 83,
       mandatedReporterCertId: 10,
+      youthGroupId: 964,
+      youthRequirementLabel: "Youth Assistant Form (Group 964)",
       intakeRequirements: [
         { requirementId: 0, label: "Background Check", type: "background_check" as const, sortOrder: 1 },
         { requirementId: 83, label: "CPP", type: "form" as const, sortOrder: 2 },
@@ -129,6 +131,7 @@ describe("SummerBlastService.getIntakeCards", () => {
             Image_GUID: null,
             Email_Address: null,
             Mobile_Phone: null,
+            Date_of_Birth: null,
           },
         ]);
       }
@@ -182,6 +185,7 @@ describe("SummerBlastService.getIntakeCards", () => {
             Image_GUID: null,
             Email_Address: null,
             Mobile_Phone: null,
+            Date_of_Birth: null,
           },
         ]);
       }
@@ -247,6 +251,7 @@ describe("SummerBlastService.getIntakeCards", () => {
             Image_GUID: null,
             Email_Address: null,
             Mobile_Phone: null,
+            Date_of_Birth: null,
           },
         ]);
       return Promise.resolve([]);
@@ -287,6 +292,7 @@ describe("SummerBlastService.getVolunteerCards", () => {
             Image_GUID: null,
             Email_Address: null,
             Mobile_Phone: null,
+            Date_of_Birth: null,
           },
         ]);
       return Promise.resolve([]);
@@ -327,6 +333,7 @@ describe("SummerBlastService.getVolunteerCards", () => {
             Image_GUID: null,
             Email_Address: null,
             Mobile_Phone: null,
+            Date_of_Birth: null,
           },
         ]);
       return Promise.resolve([]);
@@ -353,6 +360,200 @@ describe("SummerBlastService.getVolunteerCards", () => {
     const service = SummerBlastService.getInstance();
     const cards = await service.getVolunteerCards();
     expect(cards).toEqual([]);
+  });
+
+  it("under-18 with active Group 964 membership shows single complete youth item", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-13T12:00:00Z"));
+    mockGetTableRecords.mockImplementation((params: { table: string; filter?: string }) => {
+      if (params.table === "Group_Participants" && params.filter?.includes("Group_ID = 1031")) {
+        return Promise.resolve([
+          {
+            Group_Participant_ID: 700,
+            Participant_ID: 300,
+            Group_ID: 1031,
+            Group_Role_ID: 51,
+            Start_Date: "2026-05-01T00:00:00",
+            End_Date: null,
+            Notes: null,
+          },
+        ]);
+      }
+      if (params.table === "Group_Participants" && params.filter?.includes("Group_ID = 964")) {
+        // Youth IS a member of Group 964
+        return Promise.resolve([{ Participant_ID: 300 }]);
+      }
+      if (params.table === "Participants")
+        return Promise.resolve([{ Participant_ID: 300, Contact_ID: 400 }]);
+      if (params.table === "Contacts")
+        return Promise.resolve([
+          {
+            Contact_ID: 400,
+            First_Name: "Young",
+            Nickname: null,
+            Last_Name: "Volunteer",
+            Image_GUID: null,
+            Email_Address: null,
+            Mobile_Phone: null,
+            Date_of_Birth: "2010-01-15T00:00:00", // age 16 at 2026-05-13
+          },
+        ]);
+      return Promise.resolve([]);
+    });
+
+    try {
+      const service = SummerBlastService.getInstance();
+      const cards = await service.getVolunteerCards();
+      expect(cards).toHaveLength(1);
+      expect(cards[0].age).toBe(16);
+      expect(cards[0].checklist).toHaveLength(1);
+      expect(cards[0].checklist[0].type).toBe("group_membership");
+      expect(cards[0].checklist[0].status).toBe("complete");
+      expect(cards[0].isFullyCompliant).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("under-18 without Group 964 membership shows single not_started youth item", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-13T12:00:00Z"));
+    mockGetTableRecords.mockImplementation((params: { table: string; filter?: string }) => {
+      if (params.table === "Group_Participants" && params.filter?.includes("Group_ID = 1031")) {
+        return Promise.resolve([
+          {
+            Group_Participant_ID: 701,
+            Participant_ID: 301,
+            Group_ID: 1031,
+            Group_Role_ID: 51,
+            Start_Date: "2026-05-01T00:00:00",
+            End_Date: null,
+            Notes: null,
+          },
+        ]);
+      }
+      if (params.table === "Group_Participants" && params.filter?.includes("Group_ID = 964")) {
+        // Youth is NOT a member
+        return Promise.resolve([]);
+      }
+      if (params.table === "Participants")
+        return Promise.resolve([{ Participant_ID: 301, Contact_ID: 401 }]);
+      if (params.table === "Contacts")
+        return Promise.resolve([
+          {
+            Contact_ID: 401,
+            First_Name: "Pending",
+            Nickname: null,
+            Last_Name: "Youth",
+            Image_GUID: null,
+            Email_Address: null,
+            Mobile_Phone: null,
+            Date_of_Birth: "2010-01-15T00:00:00",
+          },
+        ]);
+      return Promise.resolve([]);
+    });
+
+    try {
+      const service = SummerBlastService.getInstance();
+      const cards = await service.getVolunteerCards();
+      expect(cards).toHaveLength(1);
+      expect(cards[0].checklist).toHaveLength(1);
+      expect(cards[0].checklist[0].status).toBe("not_started");
+      expect(cards[0].isFullyCompliant).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("18+ adult uses role-based requirements, not youth path", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-13T12:00:00Z"));
+    mockGetTableRecords.mockImplementation((params: { table: string; filter?: string }) => {
+      if (params.table === "Group_Participants" && params.filter?.includes("Group_ID = 1031")) {
+        return Promise.resolve([
+          {
+            Group_Participant_ID: 702,
+            Participant_ID: 302,
+            Group_ID: 1031,
+            Group_Role_ID: 42, // Chow → CPP only
+            Start_Date: "2026-05-01T00:00:00",
+            End_Date: null,
+            Notes: null,
+          },
+        ]);
+      }
+      if (params.table === "Participants")
+        return Promise.resolve([{ Participant_ID: 302, Contact_ID: 402 }]);
+      if (params.table === "Contacts")
+        return Promise.resolve([
+          {
+            Contact_ID: 402,
+            First_Name: "Adult",
+            Nickname: null,
+            Last_Name: "Volunteer",
+            Image_GUID: null,
+            Email_Address: null,
+            Mobile_Phone: null,
+            Date_of_Birth: "1990-01-15T00:00:00", // 36
+          },
+        ]);
+      return Promise.resolve([]);
+    });
+
+    try {
+      const service = SummerBlastService.getInstance();
+      const cards = await service.getVolunteerCards();
+      expect(cards).toHaveLength(1);
+      expect(cards[0].age).toBe(36);
+      // Chow role config has only CPP (1 item), not the group_membership item
+      expect(cards[0].checklist).toHaveLength(1);
+      expect(cards[0].checklist[0].type).toBe("form");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("null DOB takes adult path", async () => {
+    mockGetTableRecords.mockImplementation((params: { table: string; filter?: string }) => {
+      if (params.table === "Group_Participants" && params.filter?.includes("Group_ID = 1031")) {
+        return Promise.resolve([
+          {
+            Group_Participant_ID: 703,
+            Participant_ID: 303,
+            Group_ID: 1031,
+            Group_Role_ID: 1,
+            Start_Date: "2026-05-01T00:00:00",
+            End_Date: null,
+            Notes: null,
+          },
+        ]);
+      }
+      if (params.table === "Participants")
+        return Promise.resolve([{ Participant_ID: 303, Contact_ID: 403 }]);
+      if (params.table === "Contacts")
+        return Promise.resolve([
+          {
+            Contact_ID: 403,
+            First_Name: "No",
+            Nickname: null,
+            Last_Name: "Birthday",
+            Image_GUID: null,
+            Email_Address: null,
+            Mobile_Phone: null,
+            Date_of_Birth: null,
+          },
+        ]);
+      return Promise.resolve([]);
+    });
+
+    const service = SummerBlastService.getInstance();
+    const cards = await service.getVolunteerCards();
+    expect(cards).toHaveLength(1);
+    expect(cards[0].age).toBeNull();
+    // Temp role 1 falls back to intake requirements (3 items)
+    expect(cards[0].checklist).toHaveLength(3);
+    expect(cards[0].checklist.every((c) => c.type !== "group_membership")).toBe(true);
   });
 });
 

--- a/src/services/summerBlastService.ts
+++ b/src/services/summerBlastService.ts
@@ -1,6 +1,6 @@
 import { MPHelper } from "@/lib/providers/ministry-platform";
 import { sanitizeIds } from "@/lib/providers/ministry-platform/utils/filter-sanitize";
-import { nowCentral } from "@/lib/processing-utils";
+import { nowCentral, getAge } from "@/lib/processing-utils";
 import {
   getSummerBlastConfig,
   getRequirementsForRole,
@@ -106,6 +106,7 @@ interface ContactRecord {
   Image_GUID: string | null;
   Email_Address: string | null;
   Mobile_Phone: string | null;
+  Date_of_Birth: string | null;
 }
 
 interface BackgroundCheckRecord {
@@ -223,10 +224,22 @@ export class SummerBlastService {
     const contactIds = [...peopleByParticipant.values()].map((p) => p.Contact_ID);
     const allParticipantIds = [...peopleByParticipant.keys()];
 
-    const [bgChecks, certifications, formResponses] = await Promise.all([
+    // Compute ages and split adults from youths.
+    const ageByParticipant = new Map<number, number | null>();
+    const youthParticipantIds: number[] = [];
+    for (const r of dedupedResponses) {
+      const c = contacts.get(r.Participant_ID);
+      if (!c) continue;
+      const age = getAge(c.Date_of_Birth);
+      ageByParticipant.set(r.Participant_ID, age);
+      if (age !== null && age < 18) youthParticipantIds.push(r.Participant_ID);
+    }
+
+    const [bgChecks, certifications, formResponses, youthMembers] = await Promise.all([
       this.fetchBackgroundChecks(contactIds),
       this.fetchCertifications(allParticipantIds),
       this.fetchFormResponses(contactIds),
+      this.fetchYouthGroupMembers(youthParticipantIds),
     ]);
     const bgTypeNames = await this.fetchBgCheckTypeNames(bgChecks);
     const cutoff = this.getCutoffDate();
@@ -235,17 +248,21 @@ export class SummerBlastService {
     for (const r of dedupedResponses) {
       const info = peopleByParticipant.get(r.Participant_ID);
       if (!info) continue;
+      const age = ageByParticipant.get(r.Participant_ID) ?? null;
+      const isYouth = age !== null && age < 18;
 
-      const checklist = this.buildChecklist(
-        info.Contact_ID,
-        info.Participant_ID,
-        this.config.intakeRequirements,
-        bgChecks,
-        certifications,
-        formResponses,
-        bgTypeNames,
-        cutoff,
-      );
+      const checklist = isYouth
+        ? this.buildYouthChecklist(youthMembers.has(r.Participant_ID))
+        : this.buildChecklist(
+            info.Contact_ID,
+            info.Participant_ID,
+            this.config.intakeRequirements,
+            bgChecks,
+            certifications,
+            formResponses,
+            bgTypeNames,
+            cutoff,
+          );
 
       cards.push({
         info,
@@ -254,6 +271,7 @@ export class SummerBlastService {
         totalCount: checklist.length,
         isFullyCompliant: checklist.every((c) => c.status === "complete"),
         hasWillExpire: checklist.some((c) => c.status === "will_expire"),
+        age,
         responseId: r.Response_ID,
         responseDate: r.Response_Date,
         comments: r.Comments,
@@ -297,10 +315,22 @@ export class SummerBlastService {
 
     const contactIds = [...contacts.values()].map((c) => c.Contact_ID);
 
-    const [bgChecks, certifications, formResponses] = await Promise.all([
+    // Compute ages and split adults from youths.
+    const ageByParticipant = new Map<number, number | null>();
+    const youthParticipantIds: number[] = [];
+    for (const gp of deduped) {
+      const c = contacts.get(gp.Participant_ID);
+      if (!c) continue;
+      const age = getAge(c.Date_of_Birth);
+      ageByParticipant.set(gp.Participant_ID, age);
+      if (age !== null && age < 18) youthParticipantIds.push(gp.Participant_ID);
+    }
+
+    const [bgChecks, certifications, formResponses, youthMembers] = await Promise.all([
       this.fetchBackgroundChecks(contactIds),
       this.fetchCertifications(participantIds),
       this.fetchFormResponses(contactIds),
+      this.fetchYouthGroupMembers(youthParticipantIds),
     ]);
     const bgTypeNames = await this.fetchBgCheckTypeNames(bgChecks);
     const cutoff = this.getCutoffDate();
@@ -323,17 +353,21 @@ export class SummerBlastService {
         Mobile_Phone: c.Mobile_Phone,
       };
 
-      const requirements = getRequirementsForRole(this.config, gp.Group_Role_ID);
-      const checklist = this.buildChecklist(
-        info.Contact_ID,
-        info.Participant_ID,
-        requirements,
-        bgChecks,
-        certifications,
-        formResponses,
-        bgTypeNames,
-        cutoff,
-      );
+      const age = ageByParticipant.get(gp.Participant_ID) ?? null;
+      const isYouth = age !== null && age < 18;
+
+      const checklist = isYouth
+        ? this.buildYouthChecklist(youthMembers.has(gp.Participant_ID))
+        : this.buildChecklist(
+            info.Contact_ID,
+            info.Participant_ID,
+            getRequirementsForRole(this.config, gp.Group_Role_ID),
+            bgChecks,
+            certifications,
+            formResponses,
+            bgTypeNames,
+            cutoff,
+          );
 
       cards.push({
         info,
@@ -342,6 +376,7 @@ export class SummerBlastService {
         totalCount: checklist.length,
         isFullyCompliant: checklist.every((i) => i.status === "complete"),
         hasWillExpire: checklist.some((i) => i.status === "will_expire"),
+        age,
         groupParticipantId: gp.Group_Participant_ID,
         groupRoleId: gp.Group_Role_ID,
         groupRoleLabel:
@@ -448,6 +483,44 @@ export class SummerBlastService {
   // -------------------------------------------------------------------------
   // Private helpers
   // -------------------------------------------------------------------------
+
+  /** Fetch the set of participant IDs that are active members of the youth group. */
+  private async fetchYouthGroupMembers(
+    youthParticipantIds: number[],
+  ): Promise<Set<number>> {
+    if (youthParticipantIds.length === 0) return new Set();
+    const now = nowCentral();
+    const all: { Participant_ID: number }[] = [];
+    for (let i = 0; i < youthParticipantIds.length; i += BATCH_SIZE) {
+      const batchIds = youthParticipantIds.slice(i, i + BATCH_SIZE);
+      const batch = await this.mp.getTableRecords<{ Participant_ID: number }>({
+        table: "Group_Participants",
+        select: "Participant_ID",
+        filter: `Group_ID = ${this.config.youthGroupId} AND (End_Date IS NULL OR End_Date >= '${now}') AND Participant_ID IN (${sanitizeIds(batchIds)})`,
+      });
+      all.push(...batch);
+    }
+    return new Set(all.map((r) => r.Participant_ID));
+  }
+
+  /** Single-item checklist for an under-18 volunteer: are they in Group 964? */
+  private buildYouthChecklist(isMember: boolean): SummerBlastChecklistItem[] {
+    return [
+      {
+        key: `youth-${this.config.youthGroupId}`,
+        label: this.config.youthRequirementLabel,
+        type: "group_membership",
+        completed: isMember,
+        date: null,
+        expires: null,
+        status: isMember ? "complete" : "not_started",
+        detail: null,
+        order: 1,
+        recordId: null,
+        bgCheckDetail: null,
+      },
+    ];
+  }
 
   private buildChecklist(
     contactId: number,
@@ -592,7 +665,7 @@ export class SummerBlastService {
       const batch = await this.mp.getTableRecords<ContactRecord>({
         table: "Contacts",
         select:
-          "Contact_ID,First_Name,Nickname,Last_Name,dp_fileUniqueId AS Image_GUID,Email_Address,Mobile_Phone",
+          "Contact_ID,First_Name,Nickname,Last_Name,dp_fileUniqueId AS Image_GUID,Email_Address,Mobile_Phone,Date_of_Birth",
         filter: `Contact_ID IN (${sanitizeIds(batchIds)})`,
       });
       allContacts.push(...batch);


### PR DESCRIPTION
## Summary

Two visual signals + one structural change on the Summer Blast cards:

1. **Age** displayed under the name on both Signups (Tab 1) and Volunteers (Tab 2) cards when `Date_of_Birth` is known.
2. **"Youth" pill** (indigo, top-left) when age < 18 — distinct from the status badges in the top-right slot.
3. **Youth-specific requirement**: under-18 volunteers see a single `group_membership` checklist item instead of the normal Background Check / CPP / Mandated Reporter trio (or per-role list). Status `complete` iff the participant has an active row in **Group 964** ("Youth Assistant" — group membership is how MP signals the youth assistant form is complete).

## Files changed

| Path | Change |
|---|---|
| `data/summer-blast-config.json` | Added `youthGroupId: 964`, `youthRequirementLabel` |
| `src/lib/summer-blast-config.ts` | Zod + TS type for the new fields |
| `src/lib/dto/summer-blast.ts` | `age: number \| null` on shared card; `"group_membership"` added to item-type union |
| `src/lib/processing-utils.ts` | New `getAge()` helper (local-date parsing) |
| `src/lib/processing-utils.test.ts` | 9 new `getAge` cases |
| `src/services/summerBlastService.ts` | Select `Date_of_Birth`; batched Group 964 lookup; branched checklist builder |
| `src/services/summerBlastService.test.ts` | 4 new youth-path cases |
| `src/components/summer-blast-volunteers/volunteer-card.tsx` | Pill + age line |
| `src/components/summer-blast-volunteers/intake-card.tsx` | Pill + age line |

## Test plan

- [ ] Open Tab 2 (Volunteers); find a known under-18 volunteer → "Youth" pill top-left, "Age N" under name, checklist shows the single "Youth Assistant Form (Group 964)" item.
- [ ] If the youth IS an active member of Group 964 → item green/complete; card chip says "Compliant".
- [ ] If the youth is NOT in Group 964 → item is "not_started"; card chip says "Missing".
- [ ] Find an 18+ volunteer → no pill, age shown, normal role-specific requirements unchanged.
- [ ] Find a volunteer with null DOB → no pill, no age, adult requirements applied.
- [ ] Repeat the same on Tab 1 (Signups) for any minors with open Opp-85 responses.

## Security review

- New filter on Group_Participants is `Group_ID = <literal config>` + `Participant_ID IN (sanitizeIds(...))` — no user-controlled input.
- Existing RBAC + rate-limit guards unchanged.
- No new write paths.

## Deployment note

`data/summer-blast-config.json` gained two required fields. The Zod schema will reject the old config at startup. On deploy:

```bash
docker --context tmc1 cp data/summer-blast-config.json mpcharts-mp-charts-1:/app/data/summer-blast-config.json
docker --context tmc1 exec -u root mpcharts-mp-charts-1 chown nextjs:nodejs /app/data/summer-blast-config.json
```

If you forget, the page will throw with a clear Zod error in container logs.

495/495 tests pass, build clean, lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)