### PR TITLE
feat(processing,admin): multi-file uploads + refresh milestones from MP

### DIFF
--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -27,6 +27,8 @@ Ideas and enhancements for the MPNext project. This file syncs bidirectionally w
 
 ### Improvements
 - [Serving metrics: reconcile adult-only vs all-ages counts (#110)](#serving-metrics-reconcile-adult-only-vs-all-ages-counts-110)
+- ~~[Need to be able to pull in fresh milestones (#171)](#need-to-be-able-to-pull-in-fresh-milestones-171)~~ ✅
+- ~~[Add two files at once to a milestone (#170)](#add-two-files-at-once-to-a-milestone-170)~~ ✅
 - ~~[Card Summaries should have sections (#163)](#card-summaries-should-have-sections-163)~~ ✅
 - ~~[see all groups (#162)](#see-all-groups-162)~~ ✅
 - ~~[Use Nickname Last name on contact logs (#129)](#use-nickname-last-name-on-contact-logs-129)~~ ✅
@@ -161,6 +163,12 @@ Extracted `statusBadgeColor` to shared utility (`src/lib/contact-badge-utils.ts`
 ---
 
 ## Improvements
+
+### ~~Need to be able to pull in fresh milestones ([#171](https://github.com/The-Moody-Church/mp-charts/issues/171))~~ ✅ COMPLETED
+Added "Refresh from MP" buttons to the admin Journey Tool editor (Milestones section) and admin Compliance Tool editor (Requirements section and Journey Milestones section). Each button re-fetches the relevant data from Ministry Platform and merges with current in-memory edits — label, visibility, sort order, and other configuration are preserved for milestones/requirements that already existed; newly-added items in MP are appended at the end with default settings.
+
+### ~~Add two files at once to a milestone ([#170](https://github.com/The-Moody-Church/mp-charts/issues/170))~~ ✅ COMPLETED
+The shared `QuickActionsPanel` (used by compliance + journey processing to complete a milestone) and `MilestoneEditForm` (used to edit an already-completed milestone) now accept multiple file attachments. Adds the HTML `multiple` attribute and validates each selected file against the 20 MB-per-file limit. Adding additional paperwork to a completed milestone is covered by the existing Edit button on completed records, which now also supports multi-file upload.
 
 ### Serving metrics: reconcile adult-only vs all-ages counts ([#110](https://github.com/The-Moody-Church/mp-charts/issues/110))
 The Engagement Overview Venn diagram filters serving/leading to **adults only** (18+ or unknown birthdate), showing ~830. The Grow in Love section's "Serving by Role Type" counts **all ages**, showing ~1,022. The ~192-person gap is minors with active serving/leading roles (e.g., student volunteers). Need to decide: should the Grow in Love charts also filter to adults, or should the Venn diagram include all ages? Or add an "(all ages)" note to the Grow in Love description to make the difference explicit?

--- a/docs/sessions/session-summary-2026-05-14.md
+++ b/docs/sessions/session-summary-2026-05-14.md
@@ -1,0 +1,39 @@
+# Session Summary — 2026-05-14
+
+## Objectives
+
+Address two user-feedback issues in a single quick PR:
+
+- **#170** Add two files at once to a milestone (and add paperwork to a completed milestone)
+- **#171** Need to be able to pull in fresh milestones (refresh button on admin tool editors)
+
+## Issues Addressed
+
+| # | Status | Notes |
+|---|--------|-------|
+| #170 | COMPLETED | Multi-file upload on QuickActionsPanel + MilestoneEditForm (both shared, so journey + compliance flows both benefit). "Add paperwork to completed milestone" covered by existing Edit button + new multi-file. |
+| #171 | COMPLETED | "Refresh from MP" buttons added to admin Journey Tool editor (Milestones) and admin Compliance Tool editor (Requirements + Journey Milestones). Merge logic preserves in-memory edits. |
+
+## Files Changed
+
+- **Modified**: `src/components/processing/quick-actions-panel.tsx` — added `multiple` attribute, validate all selected files against 20 MB-per-file limit.
+- **Modified**: `src/components/processing/milestone-edit-form.tsx` — added `multiple` attribute, updated label to "Add Files (multiple allowed)".
+- **Modified**: `src/components/admin/journey-tools/journey-tool-editor.tsx` — added `handleRefreshMilestones` that re-fetches and merges against current `milestones` state (preserves edits); added Refresh from MP button next to the Milestones legend.
+- **Modified**: `src/components/admin/compliance-tools/compliance-tool-editor.tsx` — extracted `fetchAndMergeRequirements` helper, added `handleRefreshRequirements` and `handleRefreshMilestones`, added two Refresh from MP buttons (Requirements and Journey Milestones sections).
+- **Modified**: `docs/ideas.md` — marked #170 and #171 completed.
+- **Modified**: `docs/status.md` — added 2026-05-14 entry, removed 2026-05-05 (>7d), added #136 to Open Issues.
+
+## Key Decisions
+
+- **Multi-file scope**: Both compliance and journey flows benefit because `QuickActionsPanel` and `MilestoneEditForm` are shared. Server actions (`extractValidatedFiles` in `src/components/shared-actions/processing.ts`) already iterate `formData.entries()` looking for all `files` entries, so the backend needed no changes.
+- **"Add paperwork to completed milestone"**: The Edit button is already shown on completed milestone records (`compliance-detail-modal.tsx:952`). Multi-file in the edit form satisfies this — no separate "add file" affordance needed.
+- **Refresh merge semantics**: Manual refresh preserves current in-memory edits (not just edits saved to disk). New milestones/requirements appear after the user's last sort-order position so their existing order is preserved.
+
+## Pre-PR Checklist
+
+- [x] Lint: no new issues (same 11 pre-existing warnings/errors as `main`)
+- [x] Typecheck: no errors in modified files (same 42 pre-existing test-file errors as `main`)
+- [x] Tests: all 495 pass
+- [x] Security: no new filter interpolation, no new server actions, no new file upload entry points (existing `extractValidatedFiles` already validates MIME type)
+- [x] ideas.md updated
+- [x] status.md updated

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,14 +2,14 @@
 
 Quick-reference snapshot of current project state. Read this first at session start. For full details on any item, see the relevant session summary in `docs/sessions/`.
 
-**Last updated**: 2026-05-13
+**Last updated**: 2026-05-14
 
 ## Recently Completed
 
 | Date | Work | Issues | PR |
 |------|------|--------|---|
+| 2026-05-14 | **Multi-file uploads + Refresh from MP**: Quick-Action and Edit forms in compliance/journey processing now accept multiple file attachments per milestone (validated per-file against 20 MB limit). Admin Journey and Compliance Tool editors have "Refresh from MP" buttons that re-fetch milestones/requirements and merge with current in-memory edits without losing label, visibility, or sort-order changes. | #170, #171 | (pending) |
 | 2026-05-13 | **Summer Blast Volunteers tool**: New bespoke route at `/summer-blast-volunteers` with two tabs (open Opportunity 85 signups, active Group 1031 volunteers), event-cutoff "Will Expire" badge (anything expiring before 2026-07-31), CPP/Mandated Reporter quick-add, "Added to SB Spreadsheet" enrollment that creates a Group_Participant and closes the Response, role-specific requirements config (per Group_Role_ID 42-52, with Temp role 1 falling back to BG+CPP+MR). Service + 17 unit tests, cache warming registered. | — | (pending) |
-| 2026-05-05 | **Contact lookup: Groups section + sectioned compliance cards**: Added a "Groups" section to the contact lookup detail page that lists every active Group_Participant for the contact (clickable via the In a Group / Serving badges, lazy-loaded). Compliance cards now split the checklist into Requirements vs Milestones sections. | #162, #163 | (pending) |
 
 ## Planned
 
@@ -20,6 +20,7 @@ Quick-reference snapshot of current project state. Read this first at session st
 - [**#110** — Serving metrics: reconcile adult-only vs all-ages counts](ideas.md#serving-metrics-reconcile-adult-only-vs-all-ages-counts-110)
 - [**#72** — Dashboard subpages per journey step](ideas.md#and-more-specific-dashboard-subpages-72)
 - [**#161** — student leaders](https://github.com/The-Moody-Church/mp-charts/issues/161)
+- [**#136** — Upgrade TypeScript 5.9 → 6.0](ideas.md#upgrade-typescript-59-to-60-136)
 
 ## Key Architecture Notes
 

--- a/src/components/admin/compliance-tools/compliance-tool-editor.tsx
+++ b/src/components/admin/compliance-tools/compliance-tool-editor.tsx
@@ -141,33 +141,29 @@ export function ComplianceToolEditor({ existingTool, existingSlugs, usedJourneyI
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // When group role selection changes, fetch requirements
-  const handleGroupRoleToggle = async (roleId: number, checked: boolean) => {
-    const newIds = checked
-      ? [...selectedGroupRoleIds, roleId]
-      : selectedGroupRoleIds.filter(id => id !== roleId);
-    setSelectedGroupRoleIds(newIds);
-    clearFieldError("groupRoleIds");
-
-    if (newIds.length === 0) {
+  // Fetch requirements from MP for the given role IDs, merging with current state to
+  // preserve user edits (labels, visibility, sort order). New items get appended.
+  const fetchAndMergeRequirements = async (roleIds: number[]) => {
+    if (roleIds.length === 0) {
       setRequirements([]);
       return;
     }
-
     setLoadingRequirements(true);
     try {
-      const resolved = await getDeduplicatedRequirements(newIds);
-      // Merge with existing requirements (preserve user edits like labels, visibility, order)
+      const resolved = await getDeduplicatedRequirements(roleIds);
       const existingMap = new Map(requirements.map(r => [`${r.type}:${r.requirementId}`, r]));
-      const merged: ComplianceRequirementConfig[] = resolved.map((r, idx) => {
+      const maxSortOrder = requirements.reduce((max, r) => Math.max(max, r.sortOrder), 0);
+      let nextSortOrder = maxSortOrder;
+      const merged: ComplianceRequirementConfig[] = resolved.map((r) => {
         const key = `${r.type}:${r.requirementId}`;
         const existing = existingMap.get(key);
         if (existing) return existing;
+        nextSortOrder += 1;
         return {
           requirementId: r.requirementId,
           label: r.label,
           type: r.type,
-          sortOrder: idx + 1,
+          sortOrder: nextSortOrder,
           visible: true,
         };
       });
@@ -178,6 +174,19 @@ export function ComplianceToolEditor({ existingTool, existingSlugs, usedJourneyI
       setLoadingRequirements(false);
     }
   };
+
+  // When group role selection changes, fetch requirements
+  const handleGroupRoleToggle = async (roleId: number, checked: boolean) => {
+    const newIds = checked
+      ? [...selectedGroupRoleIds, roleId]
+      : selectedGroupRoleIds.filter(id => id !== roleId);
+    setSelectedGroupRoleIds(newIds);
+    clearFieldError("groupRoleIds");
+    await fetchAndMergeRequirements(newIds);
+  };
+
+  // Manual refresh — re-fetch requirements from MP and merge with current edits.
+  const handleRefreshRequirements = () => fetchAndMergeRequirements(selectedGroupRoleIds);
 
   // Load requirements on initial edit
   useEffect(() => {
@@ -216,6 +225,34 @@ export function ComplianceToolEditor({ existingTool, existingSlugs, usedJourneyI
       .finally(() => setLoadingMilestones(false));
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [journeyId]);
+
+  // Manual refresh — re-fetch journey milestones from MP and merge with current edits.
+  const handleRefreshMilestones = async () => {
+    if (!journeyId) return;
+    setLoadingMilestones(true);
+    try {
+      const mpMilestones = await getJourneyMilestones(journeyId);
+      const currentByIds = new Map(journeyMilestones.map((m) => [m.milestoneId, m]));
+      const maxSortOrder = journeyMilestones.reduce((max, m) => Math.max(max, m.sortOrder), 0);
+      let nextSortOrder = maxSortOrder;
+      const merged: ComplianceMilestoneConfig[] = mpMilestones.map((m) => {
+        const existing = currentByIds.get(m.Milestone_ID);
+        if (existing) return existing;
+        nextSortOrder += 1;
+        return {
+          milestoneId: m.Milestone_ID,
+          label: m.Milestone_Title,
+          sortOrder: nextSortOrder,
+          visible: true,
+        };
+      });
+      setJourneyMilestones(merged);
+    } catch (err) {
+      console.error("Failed to refresh milestones:", err);
+    } finally {
+      setLoadingMilestones(false);
+    }
+  };
 
   // Auto-generate slug from tool name
   const handleToolNameChange = (name: string) => {
@@ -478,7 +515,25 @@ export function ComplianceToolEditor({ existingTool, existingSlugs, usedJourneyI
 
           {/* Requirements */}
           <div className="space-y-2">
-            <Label>Requirements (toggle visibility, edit labels, reorder)</Label>
+            <div className="flex items-center justify-between gap-3">
+              <Label>Requirements (toggle visibility, edit labels, reorder)</Label>
+              {selectedGroupRoleIds.length > 0 && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleRefreshRequirements}
+                  disabled={loadingRequirements}
+                  className="gap-1.5 flex-shrink-0"
+                  title="Re-fetch requirements from Ministry Platform (preserves your edits)"
+                >
+                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                  </svg>
+                  Refresh from MP
+                </Button>
+              )}
+            </div>
             {loadingRequirements ? (
               <div className="text-sm text-muted-foreground">Loading requirements...</div>
             ) : (
@@ -513,7 +568,23 @@ export function ComplianceToolEditor({ existingTool, existingSlugs, usedJourneyI
           {/* Journey Milestones */}
           {journeyId && (
             <div className="space-y-2">
-              <Label>Journey Milestones (toggle visibility, edit labels, reorder)</Label>
+              <div className="flex items-center justify-between gap-3">
+                <Label>Journey Milestones (toggle visibility, edit labels, reorder)</Label>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleRefreshMilestones}
+                  disabled={loadingMilestones}
+                  className="gap-1.5 flex-shrink-0"
+                  title="Re-fetch milestones from Ministry Platform (preserves your edits)"
+                >
+                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                  </svg>
+                  Refresh from MP
+                </Button>
+              </div>
               {loadingMilestones ? (
                 <div className="text-sm text-muted-foreground">Loading milestones...</div>
               ) : (

--- a/src/components/admin/journey-tools/journey-tool-editor.tsx
+++ b/src/components/admin/journey-tools/journey-tool-editor.tsx
@@ -147,6 +147,36 @@ export function JourneyToolEditor({ existingTool, existingSlugs, usedJourneyIds,
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedJourneyId]);
 
+  // Manual refresh — re-fetch milestones from MP and merge with current in-memory edits.
+  // Preserves all user changes (labels, visibility, sort order, discontinue config) and
+  // appends any milestones newly added in MP since the last load.
+  const handleRefreshMilestones = async () => {
+    if (!selectedJourneyId) return;
+    setLoadingMilestones(true);
+    try {
+      const mpMilestones = await getJourneyMilestones(selectedJourneyId);
+      const currentByIds = new Map(milestones.map((m) => [m.milestoneId, m]));
+      const maxSortOrder = milestones.reduce((max, m) => Math.max(max, m.sortOrder), 0);
+      let nextSortOrder = maxSortOrder;
+      const merged: JourneyMilestoneConfig[] = mpMilestones.map((m) => {
+        const existing = currentByIds.get(m.Milestone_ID);
+        if (existing) return existing;
+        nextSortOrder += 1;
+        return {
+          milestoneId: m.Milestone_ID,
+          label: m.Milestone_Title,
+          sortOrder: nextSortOrder,
+          visible: true,
+        };
+      });
+      setMilestones(merged);
+    } catch (err) {
+      console.error("Failed to refresh milestones:", err);
+    } finally {
+      setLoadingMilestones(false);
+    }
+  };
+
   // Auto-generate slug and name from journey selection
   const handleJourneySelect = (journeyId: number) => {
     setSelectedJourneyId(journeyId);
@@ -499,9 +529,25 @@ export function JourneyToolEditor({ existingTool, existingSlugs, usedJourneyIds,
         {selectedJourneyId && (
           <fieldset className={`space-y-4 rounded-lg border p-4 ${fieldErrorClass("milestones")}`}>
             <legend className="px-2 text-sm font-semibold">Milestones</legend>
-            <p className="text-xs text-muted-foreground">
-              Toggle visibility, edit labels, reorder, and configure journey discontinuation per milestone.
-            </p>
+            <div className="flex items-start justify-between gap-3">
+              <p className="text-xs text-muted-foreground">
+                Toggle visibility, edit labels, reorder, and configure journey discontinuation per milestone.
+              </p>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleRefreshMilestones}
+                disabled={loadingMilestones}
+                className="gap-1.5 flex-shrink-0"
+                title="Re-fetch milestones from Ministry Platform (preserves your edits)"
+              >
+                <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+                Refresh from MP
+              </Button>
+            </div>
             {loadingMilestones ? (
               <div className="text-sm text-muted-foreground">Loading milestones...</div>
             ) : (

--- a/src/components/processing/milestone-edit-form.tsx
+++ b/src/components/processing/milestone-edit-form.tsx
@@ -59,9 +59,10 @@ export function MilestoneEditForm({
         )}
       </div>
       <div>
-        <Label className="text-xs">Add File</Label>
+        <Label className="text-xs">Add Files (multiple allowed)</Label>
         <Input
           type="file"
+          multiple
           ref={editFileInputRef}
           accept=".pdf,.txt,.csv,.jpg,.jpeg,.png,.gif,.bmp,.webp"
           className="text-xs h-8"

--- a/src/components/processing/quick-actions-panel.tsx
+++ b/src/components/processing/quick-actions-panel.tsx
@@ -155,17 +155,18 @@ export function QuickActionsPanel({
             </div>
           </div>
           <div>
-            <Label htmlFor="file-upload" className="text-xs">Attachment (optional)</Label>
+            <Label htmlFor="file-upload" className="text-xs">Attachments (optional, multiple allowed)</Label>
             <Input
               id="file-upload"
               type="file"
+              multiple
               ref={fileInputRef}
               accept=".pdf,.txt,.csv,.jpg,.jpeg,.png,.gif,.bmp,.webp"
               className="text-xs"
               onChange={(e) => {
-                const file = e.target.files?.[0];
-                if (file && file.size > MAX_FILE_SIZE) {
-                  onFileError(`File is too large (${(file.size / 1024 / 1024).toFixed(1)} MB). Maximum size is 20 MB.`);
+                const tooBig = Array.from(e.target.files ?? []).find((f) => f.size > MAX_FILE_SIZE);
+                if (tooBig) {
+                  onFileError(`"${tooBig.name}" is too large (${(tooBig.size / 1024 / 1024).toFixed(1)} MB). Maximum size is 20 MB per file.`);
                 } else {
                   onFileError(null);
                 }


### PR DESCRIPTION
## Summary

- **Closes #170** — Quick-Action and milestone Edit forms now accept multiple file attachments per milestone. "Add additional paperwork to a completed milestone" is covered by the existing Edit button + new multi-file support.
- **Closes #171** — "Refresh from MP" buttons added to the admin Journey Tool editor (Milestones) and admin Compliance Tool editor (Requirements + Journey Milestones). Each button re-fetches from MP and merges with current in-memory edits — labels, visibility, sort order, and other configuration are preserved.

## Changes

**Multi-file upload (shared components — applies to both compliance and journey flows):**
- `src/components/processing/quick-actions-panel.tsx` — added `multiple` attribute; `onChange` validates every selected file against the 20 MB-per-file limit (was only validating the first).
- `src/components/processing/milestone-edit-form.tsx` — added `multiple` attribute; label now reads "Add Files (multiple allowed)". Edit-save handlers in both detail modals already iterated `Array.from(files)` and validated each file's size, so no backend changes needed. The server-side `extractValidatedFiles` helper (`src/components/shared-actions/processing.ts`) already iterates all `files` entries on the FormData.

**Refresh from MP (admin tool editors):**
- `src/components/admin/journey-tools/journey-tool-editor.tsx` — new `handleRefreshMilestones` that re-fetches via `getJourneyMilestones` and merges against current `milestones` state (preserves user edits, appends new MP milestones after the user's last sort-order position). Refresh button placed next to the Milestones legend.
- `src/components/admin/compliance-tools/compliance-tool-editor.tsx` — extracted `fetchAndMergeRequirements` helper used by both `handleGroupRoleToggle` and the new `handleRefreshRequirements`; added `handleRefreshMilestones` for the Journey Milestones subsection. Two Refresh buttons added (one for Requirements, one for Journey Milestones).

## Security Review

- No new `filter:` interpolations; no `.join(",")` patterns introduced.
- No new server actions; no new file-upload entry points. The existing `extractValidatedFiles` already validates MIME type and per-file size on the server side.
- No new auth/authorization paths.
- No PII added to logs.
- Refresh handlers call existing server actions (`getJourneyMilestones`, `getDeduplicatedRequirements`) that already require admin access.

## Test plan

- [ ] Compliance tool (e.g., `/compliance/stillson-residents`): on a not-yet-completed milestone, open Quick Action, attach **2+ files**, submit, confirm both files appear under the milestone after refresh.
- [ ] Compliance tool: on an **already-completed** milestone, click Edit, attach 2+ additional files, save, confirm new files appear alongside existing attachments.
- [ ] Journey tool: same two checks as above (Quick Action + Edit on completed).
- [ ] File over 20 MB: confirm the per-file error message names the offending file by name.
- [ ] Admin → Journey Tools: open an existing tool, edit a milestone label, click "Refresh from MP", confirm the label edit is preserved.
- [ ] Admin → Compliance Tools: same as above for both Requirements and Journey Milestones sections.
- [ ] Add a new milestone in MP for a journey already wired into a tool, click Refresh in admin, confirm the new milestone appears at the end with default visibility/label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)