### PR TITLE
fix(summer-blast): surface expired BG/cert + sort signups by date

### DIFF
--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -27,6 +27,8 @@ Ideas and enhancements for the MPNext project. This file syncs bidirectionally w
 
 ### Improvements
 - [Serving metrics: reconcile adult-only vs all-ages counts (#110)](#serving-metrics-reconcile-adult-only-vs-all-ages-counts-110)
+- ~~[Summer Blast: surface expired BG/cert when a renewal is in progress](#summer-blast-surface-expired-bgcert-when-a-renewal-is-in-progress)~~ ✅
+- ~~[Summer Blast: sort signups by Response_Date (newest first)](#summer-blast-sort-signups-by-response_date-newest-first)~~ ✅
 - ~~[Summer Blast: bulk-add signups to spreadsheet](#summer-blast-bulk-add-signups-to-spreadsheet)~~ ✅
 - ~~[Summer Blast: pull fresh from MP on every load (remove caching)](#summer-blast-pull-fresh-from-mp-on-every-load-remove-caching)~~ ✅
 - ~~[Need to be able to pull in fresh milestones (#171)](#need-to-be-able-to-pull-in-fresh-milestones-171)~~ ✅
@@ -168,6 +170,12 @@ Extracted `statusBadgeColor` to shared utility (`src/lib/contact-badge-utils.ts`
 
 ### Serving metrics: reconcile adult-only vs all-ages counts ([#110](https://github.com/The-Moody-Church/mp-charts/issues/110))
 The Engagement Overview Venn diagram filters serving/leading to **adults only** (18+ or unknown birthdate), showing ~830. The Grow in Love section's "Serving by Role Type" counts **all ages**, showing ~1,022. The ~192-person gap is minors with active serving/leading roles (e.g., student volunteers). Need to decide: should the Grow in Love charts also filter to adults, or should the Venn diagram include all ages? Or add an "(all ages)" note to the Grow in Love description to make the difference explicit?
+
+### ~~Summer Blast: surface expired BG/cert when a renewal is in progress~~ ✅ COMPLETED
+`buildChecklist` now partitions records into active-valid / expired-completed / pending-or-failed and picks status accordingly. Previously, when someone had an expired BG check AND a newer pending one started after it, `.find()` returned the pending one → status fell through to "not_started". Now the same case shows "in_progress" with an inline red "expired" badge (new `previouslyExpired` flag on the DTO). When only an expired record exists with no replacement, status is "expired". CPP form responses also benefit: expired form responses no longer get masked by missing `All_Clear`-style flags.
+
+### ~~Summer Blast: sort signups by Response_Date (newest first)~~ ✅ COMPLETED
+Added a "Signup Date (Newest)" sort option, made it the default on the Signups tab. Shared `ProcessingSortOption` extended with `signup-date-desc`; `ProcessingSortSelect` accepts a custom `options` prop so other processing tabs aren't polluted with the new option. The Volunteers tab keeps its existing default sort (Last Name A–Z).
 
 ### ~~Summer Blast: bulk-add signups to spreadsheet~~ ✅ COMPLETED
 Added per-card checkboxes on the Signups tab and a sticky bulk-action bar that appears when 1+ are selected. "Confirm SB Spreadsheet Addition (Temp role) — N" creates Group_Participants in Group 1031 with Temp role for each selected signup and closes their Opportunity Responses. Partial failures are surfaced inline and the failed cards remain selected for retry; successful ones disappear with the refreshed intake list. Backed by a new `bulkAddToSummerBlast` server action that loops `SummerBlastService.addToSummerBlast` per item so one failure doesn't abort the batch.

--- a/docs/sessions/session-summary-2026-05-15.md
+++ b/docs/sessions/session-summary-2026-05-15.md
@@ -25,6 +25,33 @@ Two user-requested changes to the Summer Blast Volunteers feature:
 - **One MP write per item, not a batch.** `addToSummerBlast` already does two writes (create `Group_Participants`, update `Responses.Closed`). MP doesn't expose a true bulk operation here, so the bulk action iterates one signup at a time. Each failure is isolated.
 - **Caching removal is total, not configurable.** No `revalidate: 0` workaround or env flag — the user said "i don't wnat to cache results at all" so the cached-data.ts file is deleted and the warming entries removed entirely. If caching is wanted later it can be reintroduced.
 
+## Follow-up: Expired-status bug + signup-date sort
+
+After the no-cache + bulk-add PR (#176) merged and deployed to `:latest`, the user reported that some signup cards were showing all requirements as gray "not_started" even though the person had an expired BG check and CPP in MP.
+
+**Root cause (BG check + certification):** `buildChecklist` did `bgChecks.find((bc) => bc.Contact_ID === contactId)` — when a person had an expired completed record AND a new pending one, `.find()` returned the pending one. The pending record has `All_Clear !== true` (or `Certification_Completed === null`), so status fell through to `not_started`. The expired record was silently dropped.
+
+**Fix:** Partition matching records into three buckets — `activeValid` (Expires in future), `expiredCompleted` (Expires in past), `pendingNewer` (no Expires set / not completed). Pick status from buckets in priority order:
+1. activeValid → use `getEventExpirationStatus` (complete / will_expire)
+2. pendingNewer → `in_progress` + `previouslyExpired = true` if expiredCompleted also exists
+3. expiredCompleted → `expired`
+4. None → `not_started`
+
+Added `previouslyExpired?: boolean` to `SummerBlastChecklistItem`. New `PreviouslyExpiredInlineBadge` component renders a small red "expired" pill next to `in_progress` rows on intake card, volunteer card, and both detail modals.
+
+**Sort:** Extended `ProcessingSortOption` with `"signup-date-desc"`; `sortCards` duck-types `responseDate` on the card so the option falls back to name sort on tabs without a signup date. `ProcessingSortSelect` accepts an optional `options` prop so the new option only appears on the Signups tab. Defaults: Signups tab → Signup Date (Newest); Volunteers tab → Last Name A–Z.
+
+**Files**:
+- `src/lib/dto/summer-blast.ts` — added `previouslyExpired?: boolean`
+- `src/services/summerBlastService.ts` — refactored `buildChecklist` BG / cert / form branches
+- `src/components/summer-blast-volunteers/will-expire-badge.tsx` — added `PreviouslyExpiredInlineBadge`
+- `intake-card.tsx`, `volunteer-card.tsx`, `intake-detail-modal.tsx`, `volunteer-detail-modal.tsx` — render the new badge next to `in_progress` rows when `previouslyExpired`
+- `src/lib/processing-utils.ts` — added `signup-date-desc` option + sort case
+- `src/components/processing/processing-sort-select.tsx` — accept optional `options` prop
+- `src/components/summer-blast-volunteers/summer-blast-volunteers.tsx` — split sort state per tab, default Signups to signup-date-desc
+- `src/services/summerBlastService.test.ts` — 4 new status tests
+- `src/lib/processing-utils-sort.test.ts` — 2 new sort tests
+
 ## Pre-PR Checklist
 
 - [x] Lint: no new issues (same 11 pre-existing as on main)

--- a/docs/status.md
+++ b/docs/status.md
@@ -8,7 +8,8 @@ Quick-reference snapshot of current project state. Read this first at session st
 
 | Date | Work | Issues | PR |
 |------|------|--------|---|
-| 2026-05-15 | **Summer Blast: no cache + bulk-add**: Removed Summer Blast caching entirely — `/summer-blast-volunteers` now pulls fresh from MP on every page load (deleted `cached-data.ts`, unregistered from `cache-warming.ts`). Added per-card checkboxes on the Signups tab and a sticky bulk-action bar that confirms multi-signup enrollment as Temp role in one click (new `bulkAddToSummerBlast` action with per-item failure tracking). | — | (pending) |
+| 2026-05-15 | **Summer Blast: expired status fix + signup-date sort**: Fixed checklist status when a person had an expired BG check or certification AND a new pending one — now shows `in_progress` with an inline "expired" badge (was: incorrectly showed as `not_started`). Added "Signup Date (Newest)" sort, default on Signups tab. | — | (pending) |
+| 2026-05-15 | **Summer Blast: no cache + bulk-add**: Removed Summer Blast caching entirely — `/summer-blast-volunteers` now pulls fresh from MP on every page load (deleted `cached-data.ts`, unregistered from `cache-warming.ts`). Added per-card checkboxes on the Signups tab and a sticky bulk-action bar that confirms multi-signup enrollment as Temp role in one click (new `bulkAddToSummerBlast` action with per-item failure tracking). | — | #176 |
 | 2026-05-14 | **Multi-file uploads + Refresh from MP**: Quick-Action and Edit forms in compliance/journey processing now accept multiple file attachments per milestone (validated per-file against 20 MB limit). Admin Journey and Compliance Tool editors have "Refresh from MP" buttons that re-fetch milestones/requirements and merge with current in-memory edits without losing label, visibility, or sort-order changes. | #170, #171 | #175 |
 
 ## Planned

--- a/src/components/processing/processing-sort-select.tsx
+++ b/src/components/processing/processing-sort-select.tsx
@@ -6,9 +6,12 @@ import { SORT_OPTIONS, type ProcessingSortOption } from "@/lib/processing-utils"
 interface ProcessingSortSelectProps {
   value: ProcessingSortOption;
   onChange: (value: ProcessingSortOption) => void;
+  /** Override the default sort options list (e.g. to add tab-specific options). */
+  options?: { value: ProcessingSortOption; label: string }[];
 }
 
-export function ProcessingSortSelect({ value, onChange }: ProcessingSortSelectProps) {
+export function ProcessingSortSelect({ value, onChange, options }: ProcessingSortSelectProps) {
+  const opts = options ?? SORT_OPTIONS;
   return (
     <div className="relative w-full sm:w-fit">
       <svg
@@ -29,7 +32,7 @@ export function ProcessingSortSelect({ value, onChange }: ProcessingSortSelectPr
         onChange={(e) => onChange(e.target.value as ProcessingSortOption)}
         className="flex h-9 w-full sm:w-fit rounded-md border border-input bg-transparent pl-8 pr-3 py-1 text-base sm:text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring cursor-pointer"
       >
-        {SORT_OPTIONS.map((opt) => (
+        {opts.map((opt) => (
           <option key={opt.value} value={opt.value}>
             {opt.label}
           </option>

--- a/src/components/summer-blast-volunteers/intake-card.tsx
+++ b/src/components/summer-blast-volunteers/intake-card.tsx
@@ -7,7 +7,11 @@ import { PersonAvatar } from "@/components/processing";
 import { useRuntimeConfig } from "@/contexts";
 import { getDisplayName, formatDate } from "@/lib/processing-utils";
 import { ChecklistStatusIcon } from "./checklist-icon";
-import { WillExpireBadge, WillExpireInlineBadge } from "./will-expire-badge";
+import {
+  PreviouslyExpiredInlineBadge,
+  WillExpireBadge,
+  WillExpireInlineBadge,
+} from "./will-expire-badge";
 import type { SummerBlastIntakeCard, SummerBlastChecklistItem } from "@/lib/dto";
 
 interface Props {
@@ -138,6 +142,7 @@ function ChecklistRow({ item }: { item: SummerBlastChecklistItem }) {
       <ChecklistStatusIcon status={item.status} />
       <span className={`text-xs truncate ${textClass}`}>{item.label}</span>
       {item.status === "will_expire" && <WillExpireInlineBadge />}
+      {item.status === "in_progress" && item.previouslyExpired && <PreviouslyExpiredInlineBadge />}
     </div>
   );
 }

--- a/src/components/summer-blast-volunteers/intake-detail-modal.tsx
+++ b/src/components/summer-blast-volunteers/intake-detail-modal.tsx
@@ -14,7 +14,7 @@ import { PersonAvatar, ContactLinks } from "@/components/processing";
 import { useRuntimeConfig } from "@/contexts";
 import { getDisplayName, formatDate } from "@/lib/processing-utils";
 import { ChecklistStatusIcon } from "./checklist-icon";
-import { WillExpireInlineBadge } from "./will-expire-badge";
+import { PreviouslyExpiredInlineBadge, WillExpireInlineBadge } from "./will-expire-badge";
 import { addToSummerBlast } from "./actions";
 import type {
   SummerBlastIntakeCard,
@@ -202,6 +202,7 @@ function ChecklistRow({ item }: { item: SummerBlastChecklistItem }) {
       <ChecklistStatusIcon status={item.status} />
       <span className={textClass}>{item.label}</span>
       {item.status === "will_expire" && <WillExpireInlineBadge />}
+      {item.status === "in_progress" && item.previouslyExpired && <PreviouslyExpiredInlineBadge />}
       {item.expires && (
         <span className="ml-auto text-[11px] text-muted-foreground">
           Expires {formatDate(item.expires)}

--- a/src/components/summer-blast-volunteers/summer-blast-volunteers.tsx
+++ b/src/components/summer-blast-volunteers/summer-blast-volunteers.tsx
@@ -10,8 +10,15 @@ import {
 import {
   searchByName,
   sortCards,
+  SORT_OPTIONS,
   type ProcessingSortOption,
 } from "@/lib/processing-utils";
+
+// Signups tab has an extra "Signup Date (Newest)" option that's the default.
+const INTAKE_SORT_OPTIONS: { value: ProcessingSortOption; label: string }[] = [
+  { value: "signup-date-desc", label: "Signup Date (Newest)" },
+  ...SORT_OPTIONS,
+];
 import { Button } from "@/components/ui/button";
 import { IntakeCard } from "./intake-card";
 import { VolunteerCard } from "./volunteer-card";
@@ -56,7 +63,8 @@ export function SummerBlastVolunteers({
   const [intake, setIntake] = useState<SummerBlastIntakeCard[]>([]);
   const [volunteers, setVolunteers] = useState<SummerBlastVolunteerCard[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
-  const [sortOption, setSortOption] = useState<ProcessingSortOption>("name");
+  const [intakeSortOption, setIntakeSortOption] = useState<ProcessingSortOption>("signup-date-desc");
+  const [volunteersSortOption, setVolunteersSortOption] = useState<ProcessingSortOption>("name");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -146,12 +154,12 @@ export function SummerBlastVolunteers({
   };
 
   const filteredIntake = useMemo(
-    () => sortCards(searchByName(intake, searchQuery), sortOption),
-    [intake, searchQuery, sortOption],
+    () => sortCards(searchByName(intake, searchQuery), intakeSortOption),
+    [intake, searchQuery, intakeSortOption],
   );
   const filteredVolunteers = useMemo(
-    () => sortCards(searchByName(volunteers, searchQuery), sortOption),
-    [volunteers, searchQuery, sortOption],
+    () => sortCards(searchByName(volunteers, searchQuery), volunteersSortOption),
+    [volunteers, searchQuery, volunteersSortOption],
   );
 
   return (
@@ -192,7 +200,18 @@ export function SummerBlastVolunteers({
           </TabsList>
           <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-fit">
             <ProcessingSearchBar value={searchQuery} onChange={setSearchQuery} />
-            <ProcessingSortSelect value={sortOption} onChange={setSortOption} />
+            {activeTab === "intake" ? (
+              <ProcessingSortSelect
+                value={intakeSortOption}
+                onChange={setIntakeSortOption}
+                options={INTAKE_SORT_OPTIONS}
+              />
+            ) : (
+              <ProcessingSortSelect
+                value={volunteersSortOption}
+                onChange={setVolunteersSortOption}
+              />
+            )}
           </div>
         </div>
 

--- a/src/components/summer-blast-volunteers/summer-blast-volunteers.tsx
+++ b/src/components/summer-blast-volunteers/summer-blast-volunteers.tsx
@@ -14,9 +14,10 @@ import {
   type ProcessingSortOption,
 } from "@/lib/processing-utils";
 
-// Signups tab has an extra "Signup Date (Newest)" option that's the default.
+// Signups tab has two extra "Signup Date" options; newest-first is the default.
 const INTAKE_SORT_OPTIONS: { value: ProcessingSortOption; label: string }[] = [
   { value: "signup-date-desc", label: "Signup Date (Newest)" },
+  { value: "signup-date-asc", label: "Signup Date (Oldest)" },
   ...SORT_OPTIONS,
 ];
 import { Button } from "@/components/ui/button";

--- a/src/components/summer-blast-volunteers/volunteer-card.tsx
+++ b/src/components/summer-blast-volunteers/volunteer-card.tsx
@@ -6,7 +6,11 @@ import { PersonAvatar } from "@/components/processing";
 import { useRuntimeConfig } from "@/contexts";
 import { getDisplayName } from "@/lib/processing-utils";
 import { ChecklistStatusIcon } from "./checklist-icon";
-import { WillExpireBadge, WillExpireInlineBadge } from "./will-expire-badge";
+import {
+  PreviouslyExpiredInlineBadge,
+  WillExpireBadge,
+  WillExpireInlineBadge,
+} from "./will-expire-badge";
 import type { SummerBlastVolunteerCard, SummerBlastChecklistItem } from "@/lib/dto";
 
 interface Props {
@@ -120,6 +124,7 @@ function ChecklistRow({ item }: { item: SummerBlastChecklistItem }) {
       <ChecklistStatusIcon status={item.status} />
       <span className={`text-xs truncate ${textClass}`}>{item.label}</span>
       {item.status === "will_expire" && <WillExpireInlineBadge />}
+      {item.status === "in_progress" && item.previouslyExpired && <PreviouslyExpiredInlineBadge />}
     </div>
   );
 }

--- a/src/components/summer-blast-volunteers/volunteer-detail-modal.tsx
+++ b/src/components/summer-blast-volunteers/volunteer-detail-modal.tsx
@@ -13,7 +13,7 @@ import { PersonAvatar, ContactLinks } from "@/components/processing";
 import { useRuntimeConfig } from "@/contexts";
 import { getDisplayName, formatDate } from "@/lib/processing-utils";
 import { ChecklistStatusIcon } from "./checklist-icon";
-import { WillExpireInlineBadge } from "./will-expire-badge";
+import { PreviouslyExpiredInlineBadge, WillExpireInlineBadge } from "./will-expire-badge";
 import { removeFromSummerBlast } from "./actions";
 import type {
   SummerBlastVolunteerCard,
@@ -194,6 +194,7 @@ function ChecklistRow({ item }: { item: SummerBlastChecklistItem }) {
       <ChecklistStatusIcon status={item.status} />
       <span className={textClass}>{item.label}</span>
       {item.status === "will_expire" && <WillExpireInlineBadge />}
+      {item.status === "in_progress" && item.previouslyExpired && <PreviouslyExpiredInlineBadge />}
       {item.expires && (
         <span className="ml-auto text-[11px] text-muted-foreground">
           Expires {formatDate(item.expires)}

--- a/src/components/summer-blast-volunteers/will-expire-badge.tsx
+++ b/src/components/summer-blast-volunteers/will-expire-badge.tsx
@@ -28,3 +28,19 @@ export function WillExpireInlineBadge() {
     </span>
   );
 }
+
+/**
+ * Per-item indicator: shown next to an in_progress row when the person had a
+ * previous record that's now expired (e.g. an old BG check that expired and a
+ * new one is being processed).
+ */
+export function PreviouslyExpiredInlineBadge() {
+  return (
+    <span
+      className="inline-flex items-center rounded-sm bg-red-50 px-1 py-0 text-[9px] font-medium text-red-700"
+      title="Previously completed and now expired; a new one is in progress"
+    >
+      expired
+    </span>
+  );
+}

--- a/src/lib/dto/summer-blast.ts
+++ b/src/lib/dto/summer-blast.ts
@@ -31,6 +31,13 @@ export interface SummerBlastChecklistItem {
   recordId: number | null;
   /** Structured detail for background check items. */
   bgCheckDetail: BackgroundCheckDetail | null;
+  /**
+   * True when status is "in_progress" but the person previously had a completed
+   * record that's now expired (e.g. an old BG check that expired and a new one
+   * is currently being processed). Cards render an inline "Expired" badge in
+   * addition to the in_progress icon.
+   */
+  previouslyExpired?: boolean;
 }
 
 interface SummerBlastBaseCard {

--- a/src/lib/processing-utils-sort.test.ts
+++ b/src/lib/processing-utils-sort.test.ts
@@ -7,7 +7,8 @@ function makeCard(
   firstName: string,
   completedCount: number,
   totalCount: number,
-): BaseCardData<BasePersonInfo> {
+  responseDate?: string,
+): BaseCardData<BasePersonInfo> & { responseDate?: string } {
   return {
     info: {
       Contact_ID: 1,
@@ -22,6 +23,7 @@ function makeCard(
     checklist: [],
     completedCount,
     totalCount,
+    ...(responseDate ? { responseDate } : {}),
   };
 }
 
@@ -78,5 +80,21 @@ describe("sortCards", () => {
 
   it("returns empty array for empty input", () => {
     expect(sortCards([], "name")).toEqual([]);
+  });
+
+  it("sorts by signup-date-desc when cards have a responseDate (newest first)", () => {
+    const dated = [
+      makeCard("A", "old", 0, 1, "2026-04-01T10:00:00"),
+      makeCard("B", "new", 0, 1, "2026-05-12T10:00:00"),
+      makeCard("C", "mid", 0, 1, "2026-04-20T10:00:00"),
+    ];
+    const result = sortCards(dated, "signup-date-desc");
+    expect(result.map((c) => c.info.First_Name)).toEqual(["new", "mid", "old"]);
+  });
+
+  it("falls back to last-name sort when cards lack a responseDate", () => {
+    // No responseDate on these cards
+    const result = sortCards(cards, "signup-date-desc");
+    expect(result.map((c) => c.info.Last_Name)).toEqual(["Adams", "Adams", "Baker", "Smith"]);
   });
 });

--- a/src/lib/processing-utils-sort.test.ts
+++ b/src/lib/processing-utils-sort.test.ts
@@ -92,9 +92,29 @@ describe("sortCards", () => {
     expect(result.map((c) => c.info.First_Name)).toEqual(["new", "mid", "old"]);
   });
 
+  it("sorts by signup-date-asc when cards have a responseDate (oldest first)", () => {
+    const dated = [
+      makeCard("A", "old", 0, 1, "2026-04-01T10:00:00"),
+      makeCard("B", "new", 0, 1, "2026-05-12T10:00:00"),
+      makeCard("C", "mid", 0, 1, "2026-04-20T10:00:00"),
+    ];
+    const result = sortCards(dated, "signup-date-asc");
+    expect(result.map((c) => c.info.First_Name)).toEqual(["old", "mid", "new"]);
+  });
+
   it("falls back to last-name sort when cards lack a responseDate", () => {
     // No responseDate on these cards
-    const result = sortCards(cards, "signup-date-desc");
-    expect(result.map((c) => c.info.Last_Name)).toEqual(["Adams", "Adams", "Baker", "Smith"]);
+    expect(sortCards(cards, "signup-date-desc").map((c) => c.info.Last_Name)).toEqual([
+      "Adams",
+      "Adams",
+      "Baker",
+      "Smith",
+    ]);
+    expect(sortCards(cards, "signup-date-asc").map((c) => c.info.Last_Name)).toEqual([
+      "Adams",
+      "Adams",
+      "Baker",
+      "Smith",
+    ]);
   });
 });

--- a/src/lib/processing-utils.ts
+++ b/src/lib/processing-utils.ts
@@ -8,15 +8,16 @@ import type { BaseCardData, BasePersonInfo } from '@/lib/dto/processing-shared';
 /**
  * Available sort options for processing card grids.
  *
- * `signup-date-desc` only applies to cards that expose a `responseDate` field
- * (currently just Summer Blast intake cards). On cards without a responseDate
- * it falls back to a name sort.
+ * `signup-date-desc` and `signup-date-asc` only apply to cards that expose a
+ * `responseDate` field (currently just Summer Blast intake cards). On cards
+ * without a responseDate they fall back to a name sort.
  */
 export type ProcessingSortOption =
   | "name"
   | "most-completed"
   | "least-completed"
-  | "signup-date-desc";
+  | "signup-date-desc"
+  | "signup-date-asc";
 
 /** Label/value pairs for sort option dropdowns. */
 export const SORT_OPTIONS: { value: ProcessingSortOption; label: string }[] = [
@@ -59,6 +60,16 @@ export function sortCards<T extends BaseCardData<BasePersonInfo>>(
           return new Date(bDate).getTime() - new Date(aDate).getTime();
         }
         // Fall back to name sort when cards don't expose a responseDate.
+        return a.info.Last_Name.localeCompare(b.info.Last_Name);
+      });
+      break;
+    case "signup-date-asc":
+      sorted.sort((a, b) => {
+        const aDate = (a as { responseDate?: string }).responseDate;
+        const bDate = (b as { responseDate?: string }).responseDate;
+        if (aDate && bDate) {
+          return new Date(aDate).getTime() - new Date(bDate).getTime();
+        }
         return a.info.Last_Name.localeCompare(b.info.Last_Name);
       });
       break;

--- a/src/lib/processing-utils.ts
+++ b/src/lib/processing-utils.ts
@@ -5,8 +5,18 @@
 
 import type { BaseCardData, BasePersonInfo } from '@/lib/dto/processing-shared';
 
-/** Available sort options for processing card grids. */
-export type ProcessingSortOption = "name" | "most-completed" | "least-completed";
+/**
+ * Available sort options for processing card grids.
+ *
+ * `signup-date-desc` only applies to cards that expose a `responseDate` field
+ * (currently just Summer Blast intake cards). On cards without a responseDate
+ * it falls back to a name sort.
+ */
+export type ProcessingSortOption =
+  | "name"
+  | "most-completed"
+  | "least-completed"
+  | "signup-date-desc";
 
 /** Label/value pairs for sort option dropdowns. */
 export const SORT_OPTIONS: { value: ProcessingSortOption; label: string }[] = [
@@ -38,6 +48,17 @@ export function sortCards<T extends BaseCardData<BasePersonInfo>>(
     case "least-completed":
       sorted.sort((a, b) => {
         if (a.completedCount !== b.completedCount) return a.completedCount - b.completedCount;
+        return a.info.Last_Name.localeCompare(b.info.Last_Name);
+      });
+      break;
+    case "signup-date-desc":
+      sorted.sort((a, b) => {
+        const aDate = (a as { responseDate?: string }).responseDate;
+        const bDate = (b as { responseDate?: string }).responseDate;
+        if (aDate && bDate) {
+          return new Date(bDate).getTime() - new Date(aDate).getTime();
+        }
+        // Fall back to name sort when cards don't expose a responseDate.
         return a.info.Last_Name.localeCompare(b.info.Last_Name);
       });
       break;

--- a/src/services/summerBlastService.test.ts
+++ b/src/services/summerBlastService.test.ts
@@ -262,6 +262,271 @@ describe("SummerBlastService.getIntakeCards", () => {
     expect(cards).toHaveLength(1);
     expect(cards[0].responseId).toBe(11);
   });
+
+  // Multi-record status: someone had a BG check that expired and started a new
+  // pending one. The card should show in_progress + previouslyExpired (not the
+  // old "not_started" bug where pending overwrote the expired record).
+  it("flags previouslyExpired when an expired BG check is followed by a new pending one", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-15T12:00:00Z"));
+
+    mockGetTableRecords.mockImplementation((params: { table: string }) => {
+      if (params.table === "Responses") {
+        return Promise.resolve([
+          {
+            Response_ID: 8800,
+            Response_Date: "2026-05-11T10:00:00",
+            Opportunity_ID: 85,
+            Participant_ID: 4000,
+            Closed: false,
+            Comments: null,
+          },
+        ]);
+      }
+      if (params.table === "Participants") {
+        return Promise.resolve([{ Participant_ID: 4000, Contact_ID: 5000 }]);
+      }
+      if (params.table === "Contacts") {
+        return Promise.resolve([
+          {
+            Contact_ID: 5000,
+            First_Name: "Faith",
+            Nickname: null,
+            Last_Name: "Ridge",
+            Image_GUID: null,
+            Email_Address: null,
+            Mobile_Phone: null,
+            Date_of_Birth: null,
+          },
+        ]);
+      }
+      if (params.table === "Background_Checks") {
+        return Promise.resolve([
+          // Newest first (orderBy Background_Check_Started DESC): a new pending one
+          {
+            Background_Check_ID: 200,
+            Contact_ID: 5000,
+            Background_Check_Status_ID: 1,
+            Background_Check_Started: "2026-05-10T00:00:00",
+            Background_Check_Submitted: null,
+            Background_Check_Returned: null,
+            All_Clear: null,
+            Background_Check_Expires: null,
+            Report_Url: null,
+            Background_Check_Type_ID: 1,
+          },
+          // Older: a completed one that's now expired
+          {
+            Background_Check_ID: 100,
+            Contact_ID: 5000,
+            Background_Check_Status_ID: 1,
+            Background_Check_Started: "2024-01-01T00:00:00",
+            Background_Check_Submitted: "2024-01-05T00:00:00",
+            Background_Check_Returned: "2024-01-10T00:00:00",
+            All_Clear: true,
+            Background_Check_Expires: "2025-01-10T00:00:00",
+            Report_Url: null,
+            Background_Check_Type_ID: 1,
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    try {
+      const service = SummerBlastService.getInstance();
+      const cards = await service.getIntakeCards();
+      const bg = cards[0].checklist.find((c) => c.type === "background_check");
+      expect(bg).toBeDefined();
+      expect(bg!.status).toBe("in_progress");
+      expect(bg!.previouslyExpired).toBe(true);
+      // Display record should be the newer pending one
+      expect(bg!.recordId).toBe(200);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("shows expired when only an expired BG check exists (no new pending)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-15T12:00:00Z"));
+
+    mockGetTableRecords.mockImplementation((params: { table: string }) => {
+      if (params.table === "Responses")
+        return Promise.resolve([
+          {
+            Response_ID: 8801,
+            Response_Date: "2026-05-11T10:00:00",
+            Opportunity_ID: 85,
+            Participant_ID: 4100,
+            Closed: false,
+            Comments: null,
+          },
+        ]);
+      if (params.table === "Participants")
+        return Promise.resolve([{ Participant_ID: 4100, Contact_ID: 5100 }]);
+      if (params.table === "Contacts")
+        return Promise.resolve([
+          {
+            Contact_ID: 5100,
+            First_Name: "Solo",
+            Nickname: null,
+            Last_Name: "Expired",
+            Image_GUID: null,
+            Email_Address: null,
+            Mobile_Phone: null,
+            Date_of_Birth: null,
+          },
+        ]);
+      if (params.table === "Background_Checks") {
+        return Promise.resolve([
+          {
+            Background_Check_ID: 110,
+            Contact_ID: 5100,
+            Background_Check_Status_ID: 1,
+            Background_Check_Started: "2024-01-01T00:00:00",
+            Background_Check_Submitted: "2024-01-05T00:00:00",
+            Background_Check_Returned: "2024-01-10T00:00:00",
+            All_Clear: true,
+            Background_Check_Expires: "2025-01-10T00:00:00",
+            Report_Url: null,
+            Background_Check_Type_ID: 1,
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    try {
+      const service = SummerBlastService.getInstance();
+      const cards = await service.getIntakeCards();
+      const bg = cards[0].checklist.find((c) => c.type === "background_check");
+      expect(bg!.status).toBe("expired");
+      expect(bg!.previouslyExpired).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("shows expired when only an expired CPP form response exists", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-15T12:00:00Z"));
+
+    mockGetTableRecords.mockImplementation((params: { table: string }) => {
+      if (params.table === "Responses")
+        return Promise.resolve([
+          {
+            Response_ID: 8802,
+            Response_Date: "2026-05-11T10:00:00",
+            Opportunity_ID: 85,
+            Participant_ID: 4200,
+            Closed: false,
+            Comments: null,
+          },
+        ]);
+      if (params.table === "Participants")
+        return Promise.resolve([{ Participant_ID: 4200, Contact_ID: 5200 }]);
+      if (params.table === "Contacts")
+        return Promise.resolve([
+          {
+            Contact_ID: 5200,
+            First_Name: "Expired",
+            Nickname: null,
+            Last_Name: "CPP",
+            Image_GUID: null,
+            Email_Address: null,
+            Mobile_Phone: null,
+            Date_of_Birth: null,
+          },
+        ]);
+      if (params.table === "Form_Responses")
+        return Promise.resolve([
+          {
+            Form_Response_ID: 999,
+            Form_ID: 83,
+            Contact_ID: 5200,
+            Response_Date: "2024-06-01T00:00:00",
+            Expires: "2025-06-01T00:00:00",
+          },
+        ]);
+      return Promise.resolve([]);
+    });
+
+    try {
+      const service = SummerBlastService.getInstance();
+      const cards = await service.getIntakeCards();
+      const cpp = cards[0].checklist.find((c) => c.type === "form");
+      expect(cpp!.status).toBe("expired");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("flags previouslyExpired on certification when expired-completed precedes a failed/pending one", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-15T12:00:00Z"));
+
+    mockGetTableRecords.mockImplementation((params: { table: string }) => {
+      if (params.table === "Responses")
+        return Promise.resolve([
+          {
+            Response_ID: 8803,
+            Response_Date: "2026-05-11T10:00:00",
+            Opportunity_ID: 85,
+            Participant_ID: 4300,
+            Closed: false,
+            Comments: null,
+          },
+        ]);
+      if (params.table === "Participants")
+        return Promise.resolve([{ Participant_ID: 4300, Contact_ID: 5300 }]);
+      if (params.table === "Contacts")
+        return Promise.resolve([
+          {
+            Contact_ID: 5300,
+            First_Name: "Cert",
+            Nickname: null,
+            Last_Name: "Renewer",
+            Image_GUID: null,
+            Email_Address: null,
+            Mobile_Phone: null,
+            Date_of_Birth: null,
+          },
+        ]);
+      if (params.table === "Participant_Certifications")
+        return Promise.resolve([
+          // Newest first: a new pending cert (no Certification_Completed yet)
+          {
+            Participant_Certification_ID: 88,
+            Participant_ID: 4300,
+            Certification_Type_ID: 10,
+            Certification_Completed: null,
+            Certification_Expires: null,
+            Passed: null,
+          },
+          // Older: completed but expired
+          {
+            Participant_Certification_ID: 77,
+            Participant_ID: 4300,
+            Certification_Type_ID: 10,
+            Certification_Completed: "2024-01-01T00:00:00",
+            Certification_Expires: "2025-01-01T00:00:00",
+            Passed: true,
+          },
+        ]);
+      return Promise.resolve([]);
+    });
+
+    try {
+      const service = SummerBlastService.getInstance();
+      const cards = await service.getIntakeCards();
+      const mr = cards[0].checklist.find((c) => c.type === "certification");
+      expect(mr!.status).toBe("in_progress");
+      expect(mr!.previouslyExpired).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("SummerBlastService.getVolunteerCards", () => {

--- a/src/services/summerBlastService.ts
+++ b/src/services/summerBlastService.ts
@@ -534,34 +534,61 @@ export class SummerBlastService {
   ): SummerBlastChecklistItem[] {
     const items: SummerBlastChecklistItem[] = [];
 
+    const now = new Date();
+
     for (const req of [...requirements].sort((a, b) => a.sortOrder - b.sortOrder)) {
       switch (req.type) {
         case "background_check": {
-          const latest = bgChecks.find((bc) => bc.Contact_ID === contactId);
-          const passed = latest?.All_Clear === true;
-          const expires = latest?.Background_Check_Expires ?? null;
-          const status: SummerBlastItemStatus = !passed
-            ? "not_started"
-            : getEventExpirationStatus(expires, cutoff);
+          // All BG checks for this contact, ordered newest-first by the fetch.
+          const all = bgChecks.filter((bc) => bc.Contact_ID === contactId);
+
+          // A BG check with Expires set was completed/approved by MP at some
+          // point. Trust that as the canonical "previously valid" signal —
+          // All_Clear may not always be set on older records.
+          const activeValid = all.find(
+            (bc) => bc.Background_Check_Expires && new Date(bc.Background_Check_Expires) >= now,
+          );
+          const expiredCompleted = all.find(
+            (bc) => bc.Background_Check_Expires && new Date(bc.Background_Check_Expires) < now,
+          );
+          const pendingNewer = all.find((bc) => !bc.Background_Check_Expires);
+
+          let status: SummerBlastItemStatus;
+          let previouslyExpired = false;
+          let displayRecord: BackgroundCheckRecord | null = null;
+
+          if (activeValid) {
+            status = getEventExpirationStatus(activeValid.Background_Check_Expires, cutoff);
+            displayRecord = activeValid;
+          } else if (pendingNewer) {
+            status = "in_progress";
+            previouslyExpired = !!expiredCompleted;
+            displayRecord = pendingNewer;
+          } else if (expiredCompleted) {
+            status = "expired";
+            displayRecord = expiredCompleted;
+          } else {
+            status = "not_started";
+          }
 
           let bgDetail: BackgroundCheckDetail | null = null;
-          if (latest) {
+          if (displayRecord) {
             let bgStatus = "Pending";
-            if (latest.All_Clear === true && latest.Background_Check_Returned) bgStatus = "Completed";
-            else if (latest.Background_Check_Returned) bgStatus = "Returned";
-            else if (latest.Background_Check_Submitted) bgStatus = "Submitted";
+            if (displayRecord.All_Clear === true && displayRecord.Background_Check_Returned) bgStatus = "Completed";
+            else if (displayRecord.Background_Check_Returned) bgStatus = "Returned";
+            else if (displayRecord.Background_Check_Submitted) bgStatus = "Submitted";
             else bgStatus = "Started";
             bgDetail = {
-              typeName: latest.Background_Check_Type_ID
-                ? bgTypeNames.get(latest.Background_Check_Type_ID) ?? null
+              typeName: displayRecord.Background_Check_Type_ID
+                ? bgTypeNames.get(displayRecord.Background_Check_Type_ID) ?? null
                 : null,
               status: bgStatus,
-              started: latest.Background_Check_Started,
-              submitted: latest.Background_Check_Submitted,
-              returned: latest.Background_Check_Returned,
-              allClear: latest.All_Clear,
-              expires: latest.Background_Check_Expires,
-              reportUrl: latest.Report_Url,
+              started: displayRecord.Background_Check_Started,
+              submitted: displayRecord.Background_Check_Submitted,
+              returned: displayRecord.Background_Check_Returned,
+              allClear: displayRecord.All_Clear,
+              expires: displayRecord.Background_Check_Expires,
+              reportUrl: displayRecord.Report_Url,
             };
           }
 
@@ -571,66 +598,115 @@ export class SummerBlastService {
             type: "background_check",
             completed: status === "complete",
             date:
-              latest?.Background_Check_Returned ??
-              latest?.Background_Check_Started ??
+              displayRecord?.Background_Check_Returned ??
+              displayRecord?.Background_Check_Started ??
               null,
-            expires,
+            expires: displayRecord?.Background_Check_Expires ?? null,
             status,
-            detail: latest ? (latest.All_Clear ? "All Clear" : "Pending") : null,
+            detail: displayRecord ? (displayRecord.All_Clear ? "All Clear" : "Pending") : null,
             order: req.sortOrder,
-            recordId: latest?.Background_Check_ID ?? null,
+            recordId: displayRecord?.Background_Check_ID ?? null,
             bgCheckDetail: bgDetail,
+            previouslyExpired,
           });
           break;
         }
         case "certification": {
-          const latest = certifications.find(
+          const matching = certifications.filter(
             (c) =>
               c.Participant_ID === participantId &&
               c.Certification_Type_ID === req.requirementId,
           );
-          const passed = !!latest?.Certification_Completed && latest.Passed !== false;
-          const expires = latest?.Certification_Expires ?? null;
-          const status: SummerBlastItemStatus = passed
-            ? getEventExpirationStatus(expires, cutoff)
-            : latest
-              ? "in_progress"
-              : "not_started";
+
+          // A passed cert with an Expires date is the canonical "completed"
+          // signal; missing Certification_Expires means no expiry tracked.
+          const activeValid = matching.find(
+            (c) =>
+              c.Certification_Completed &&
+              c.Passed !== false &&
+              (!c.Certification_Expires || new Date(c.Certification_Expires) >= now),
+          );
+          const expiredCompleted = matching.find(
+            (c) =>
+              c.Certification_Completed &&
+              c.Passed !== false &&
+              c.Certification_Expires &&
+              new Date(c.Certification_Expires) < now,
+          );
+          const pendingOrFailed = matching.find(
+            (c) => !c.Certification_Completed || c.Passed === false,
+          );
+
+          let status: SummerBlastItemStatus;
+          let previouslyExpired = false;
+          let displayRecord: CertificationRecord | null = null;
+
+          if (activeValid) {
+            status = getEventExpirationStatus(activeValid.Certification_Expires, cutoff);
+            displayRecord = activeValid;
+          } else if (pendingOrFailed) {
+            status = "in_progress";
+            previouslyExpired = !!expiredCompleted;
+            displayRecord = pendingOrFailed;
+          } else if (expiredCompleted) {
+            status = "expired";
+            displayRecord = expiredCompleted;
+          } else {
+            status = "not_started";
+          }
+
           items.push({
             key: `req-${req.requirementId}-cert`,
             label: req.label,
             type: "certification",
             completed: status === "complete",
-            date: latest?.Certification_Completed ?? null,
-            expires,
+            date: displayRecord?.Certification_Completed ?? null,
+            expires: displayRecord?.Certification_Expires ?? null,
             status,
-            detail: latest?.Passed === false ? "Failed" : null,
+            detail: displayRecord?.Passed === false ? "Failed" : null,
             order: req.sortOrder,
-            recordId: latest?.Participant_Certification_ID ?? null,
+            recordId: displayRecord?.Participant_Certification_ID ?? null,
             bgCheckDetail: null,
+            previouslyExpired,
           });
           break;
         }
         case "form": {
-          const latest = formResponses.find(
+          const matching = formResponses.filter(
             (f) => f.Contact_ID === contactId && f.Form_ID === req.requirementId,
           );
-          const submitted = !!latest;
-          const expires = latest?.Expires ?? null;
-          const status: SummerBlastItemStatus = submitted
-            ? getEventExpirationStatus(expires, cutoff)
-            : "not_started";
+
+          const activeValid = matching.find(
+            (f) => !f.Expires || new Date(f.Expires) >= now,
+          );
+          const expiredResponse = matching.find(
+            (f) => f.Expires && new Date(f.Expires) < now,
+          );
+
+          let status: SummerBlastItemStatus;
+          let displayRecord: FormResponseRecord | null = null;
+
+          if (activeValid) {
+            status = getEventExpirationStatus(activeValid.Expires, cutoff);
+            displayRecord = activeValid;
+          } else if (expiredResponse) {
+            status = "expired";
+            displayRecord = expiredResponse;
+          } else {
+            status = "not_started";
+          }
+
           items.push({
             key: `req-${req.requirementId}-form`,
             label: req.label,
             type: "form",
             completed: status === "complete",
-            date: latest?.Response_Date ?? null,
-            expires,
+            date: displayRecord?.Response_Date ?? null,
+            expires: displayRecord?.Expires ?? null,
             status,
             detail: null,
             order: req.sortOrder,
-            recordId: latest?.Form_Response_ID ?? null,
+            recordId: displayRecord?.Form_Response_ID ?? null,
             bgCheckDetail: null,
           });
           break;


### PR DESCRIPTION
## Summary

Two follow-ups to the Summer Blast Volunteers tool, reported after PR #176 went live:

1. **Bug fix — expired requirements shown as `not_started`.** When a person had an expired BG check or certification AND a newer pending replacement, the card showed all three requirements as gray "not_started" icons. Reported with screenshot of Faith Ridge (May 11 signup) who has an expired BG check + CPP in MP but showed all gray on the card.
2. **Sort enhancement.** Signup cards now default to sorting by Response_Date (newest first), with the option still selectable in the dropdown.

## Root cause (bug)

`buildChecklist` did `bgChecks.find((bc) => bc.Contact_ID === contactId)`. `fetchBackgroundChecks` orders results by `Background_Check_Started DESC`, so `.find()` returned the most-recently-started record. When someone had an old expired check + a new pending replacement, the pending one was returned — its `All_Clear !== true`, so status fell through to `not_started`. The expired record was silently dropped from the UI.

Same shape of bug for certifications. CPP form responses were less affected because there's no "All_Clear" gate, but the new code still cleans up edge cases (e.g. only an expired response exists).

## Fix

Partition matching records into three buckets:
- **activeValid** — `Expires` (or `Certification_Expires`) is in the future
- **expiredCompleted** — `Expires` is in the past
- **pendingNewer** — no `Expires` set (record exists but not completed)

Pick status from buckets in priority order:
1. `activeValid` → `getEventExpirationStatus` (`complete` / `will_expire`)
2. `pendingNewer` → `in_progress`; sets `previouslyExpired = true` if `expiredCompleted` also exists
3. `expiredCompleted` → `expired`
4. None → `not_started`

New `previouslyExpired?: boolean` on `SummerBlastChecklistItem`. New `PreviouslyExpiredInlineBadge` (small red "expired" pill) renders next to `in_progress` rows on intake card, volunteer card, and both detail modals. So the answer to "where's the expired one?" is visible at a glance, without losing the "renewal in progress" signal.

## Sort

- Extend `ProcessingSortOption` with `"signup-date-desc"`. `sortCards` duck-types `responseDate` on the card so cards without that field (volunteers, baptism, membership) fall back to last-name sort.
- `ProcessingSortSelect` accepts an optional `options` prop so the new option is only injected on the Signups tab; other processing tabs keep the original three options.
- SB intake state split into `intakeSortOption` (defaults `signup-date-desc`) and `volunteersSortOption` (defaults `name`); the dropdown switches options/handler based on `activeTab`.

## Tests

- 4 new service tests in `summerBlastService.test.ts` covering:
  - expired BG + new pending → `in_progress` + `previouslyExpired: true`
  - only expired BG (no replacement) → `expired`
  - only expired CPP form → `expired`
  - expired cert + new pending → `in_progress` + `previouslyExpired: true`
- 2 new sort tests in `processing-utils-sort.test.ts` covering signup-date-desc + fallback when responseDate absent.

All 508 tests pass (was 502). Lint baseline unchanged.

## Security Review

- No changes to filter sanitization, auth, file uploads, or rate limiting.
- Bug-fix paths reorganize logic on already-fetched in-memory records; no new MP queries.
- New `PreviouslyExpiredInlineBadge` renders only when `status === "in_progress" && previouslyExpired === true` — no XSS surface; no user-controlled strings rendered.

## Test plan

- [ ] Faith Ridge's signup card now shows the BG check / CPP as either "in_progress" with an inline red "expired" badge, OR just "expired" (depending on whether MP has a new pending record).
- [ ] A signup with only an expired record (no replacement) shows the row in strikethrough red.
- [ ] A signup with a currently-valid BG check still shows green / complete.
- [ ] Signups tab opens sorted with newest signups at top by default.
- [ ] Sort dropdown on Signups tab shows "Signup Date (Newest)" first, followed by the three name/completed options.
- [ ] Sort dropdown on Volunteers tab is unchanged (three options).
- [ ] Other processing pages (volunteer, baptism, membership) sort dropdowns are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)