### PR TITLE
fix(deps): clear remaining MEDIUM alerts (js-yaml, postcss)

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -2,12 +2,13 @@
 
 Quick-reference snapshot of current project state. Read this first at session start. For full details on any item, see the relevant session summary in `docs/sessions/`.
 
-**Last updated**: 2026-05-15
+**Last updated**: 2026-06-23
 
 ## Recently Completed
 
 | Date | Work | Issues | PR |
 |------|------|--------|---|
+| 2026-06-23 | **Dependabot security cleanup**: Cleared all open security alerts. Bumped undici 7.24.4→7.28.0 + vite 8.0.5→8.1.0 (3 HIGH: SOCKS5 cross-origin routing, TLS-bypass, `server.fs.deny` Windows bypass), esbuild 0.27.3→0.28.1 (low), js-yaml 4.1.1→4.2.0 (MEDIUM YAML-merge DoS), and added a `postcss: "$postcss"` override to dedupe Next 16's exact-pinned 8.4.31 nested copy to the patched 8.5.15 (MEDIUM CSS-stringify XSS). 0 high / 0 critical remaining; `next build` + 509 tests pass. | — | #181, #180, #183 |
 | 2026-05-15 | **Summer Blast: expired status fix + signup-date sort**: Fixed checklist status when a person had an expired BG check or certification AND a new pending one — now shows `in_progress` with an inline "expired" badge (was: incorrectly showed as `not_started`). Added "Signup Date (Newest)" sort, default on Signups tab. | — | (pending) |
 | 2026-05-15 | **Summer Blast: no cache + bulk-add**: Removed Summer Blast caching entirely — `/summer-blast-volunteers` now pulls fresh from MP on every page load (deleted `cached-data.ts`, unregistered from `cache-warming.ts`). Added per-card checkboxes on the Signups tab and a sticky bulk-action bar that confirms multi-signup enrollment as Temp role in one click (new `bulkAddToSummerBlast` action with per-item failure tracking). | — | #176 |
 | 2026-05-14 | **Multi-file uploads + Refresh from MP**: Quick-Action and Edit forms in compliance/journey processing now accept multiple file attachments per milestone (validated per-file against 20 MB limit). Admin Journey and Compliance Tool editors have "Refresh from MP" buttons that re-fetch milestones/requirements and merge with current in-memory edits without losing label, visibility, or sort-order changes. | #170, #171 | #175 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -8402,10 +8402,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -9146,34 +9156,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-exports-info": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "vitest": "^4.1.0"
   },
   "overrides": {
-    "cross-spawn": "^7.0.6"
+    "cross-spawn": "^7.0.6",
+    "postcss": "$postcss"
   }
 }


### PR DESCRIPTION
## Summary

Clears the two remaining **MEDIUM** Dependabot alerts, the last open security alerts after #181 (highs) and #180 (esbuild).

| Package | Scope | Change | Alert cleared |
|---------|-------|--------|---------------|
| **js-yaml** | dev (via `@eslint/eslintrc`) | 4.1.1 → 4.2.0 | MEDIUM — quadratic-complexity DoS in YAML merge-key handling (patched 4.2.0; parent allows `^4.1.1`) |
| **postcss** | runtime (Next 16's nested copy) | `$postcss` override → dedupes to 8.5.15 | MEDIUM — XSS via unescaped `</style>` in CSS stringify output (patched 8.5.10) |

**postcss detail:** the top-level postcss was already patched (8.5.15); the lingering alert was Next 16.2.6's **exact-pinned** `8.4.31` nested copy, which Dependabot can't bump directly. Adding `"postcss": "$postcss"` to `overrides` forces that nested copy to the already-declared top-level version, leaving a single deduped postcss 8.5.15. js-yaml needed no `package.json` change (in-range lockfile bump).

## Verification

- **`npm audit`**: 0 high, 0 critical; both target mediums gone. (Remaining: 1 low `@babel/core` + 1 `brace-expansion` — out of scope, no fix needed for the HIGH gate.)
- **`next build`**: compiles successfully and generates all 18 routes **with the postcss override active** — confirms the override does not break Next's CSS pipeline.
- **`npm run test:run`**: 509 passed / 31 files.

## Security Review

Per `.claude/rules/git-workflow.md`. Changed files: `package.json` (one `overrides` line) + `package-lock.json`. No source files, no new dependencies introduced, no scripts/install hooks. The postcss override only realigns Next's nested postcss to the existing top-level patched version. No PII/logging/auth/filter-injection surface touched. **No concerns.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PJ9LNFjCq2MDCREYQZcDE
