### PR TITLE
security: hardening follow-ups (F6/F8/F9/F13/F14/F15 + latent XSS, partial F7)

### DIFF
--- a/.claude/notes/security-audit-2026-06-23.md
+++ b/.claude/notes/security-audit-2026-06-23.md
@@ -38,16 +38,16 @@ All MP API calls run as a **single shared client-credentials service account wit
 | F3 | `deleteContactLog` has no ownership check | **HIGH** | Broken Access Control | ✅ Fixed (PR) |
 | F4 | User-profile actions accept an arbitrary GUID | **HIGH** | Broken Access Control | ✅ Fixed (PR) |
 | F5 | Open redirect via backslash bypass of `getSafeCallbackUrl` | **MEDIUM** | Redirect | ✅ Fixed (PR) |
-| F6 | MP error-response body (incl. PII) logged unredacted (~40 sites) | **MEDIUM** | Data Exposure | Open |
-| F7 | Document uploads skip size check + use wrong rate-limit tier | **LOW** | Input Validation / Abuse | Open |
-| F8 | `bulkAddToSummerBlast` accepts an unbounded array | **MEDIUM** | DoS / Abuse | Open |
-| F9 | PII-read actions use `general` tier, not `search` | **LOW** | Abuse | Open |
+| F6 | MP error-response body (incl. PII) logged unredacted (~40 sites) | **MEDIUM** | Data Exposure | ✅ Fixed (follow-up PR) |
+| F7 | Document uploads skip size check + use wrong rate-limit tier | **LOW** | Input Validation / Abuse | ⚠️ Size check fixed (follow-up PR); `upload` tier reassignment deferred |
+| F8 | `bulkAddToSummerBlast` accepts an unbounded array | **MEDIUM** | DoS / Abuse | ✅ Fixed (follow-up PR) |
+| F9 | PII-read actions use `general` tier, not `search` | **LOW** | Abuse | ✅ Fixed (follow-up PR) |
 | F10 | Unvalidated `year` arg → uncapped cache map growth | **LOW** | DoS | Open |
 | F11 | `/admin` page renders shell without server-side role gate | **LOW** | Authorization (defense-in-depth) | Open |
 | F12 | Authz profile cached 15 min → revocation lag | **LOW** | Authorization | Open |
-| F13 | No timeout/`AbortSignal` on outbound fetch | **LOW** | Availability | Open |
-| F14 | Missing COOP / CORP headers | **LOW** | Configuration | Open |
-| F15 | `sanitizeFilterValue` does not escape LIKE wildcards | **LOW** | Injection (low) | Open |
+| F13 | No timeout/`AbortSignal` on outbound fetch | **LOW** | Availability | ✅ Fixed (follow-up PR) |
+| F14 | Missing COOP / CORP headers | **LOW** | Configuration | ✅ Fixed (follow-up PR) |
+| F15 | `sanitizeFilterValue` does not escape LIKE wildcards | **LOW** | Injection (low) | ✅ Fixed (follow-up PR) — `sanitizeLikeValue` |
 | F16 | Rate-limit tiers are independent buckets | **LOW** | Abuse | Open |
 
 ---

--- a/next.config.ts
+++ b/next.config.ts
@@ -24,6 +24,10 @@ const nextConfig: NextConfig = {
           { key: 'X-Content-Type-Options', value: 'nosniff' },
           { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
           { key: 'X-DNS-Prefetch-Control', value: 'on' },
+          // F14: isolate our browsing context and same-origin resources.
+          // COEP is intentionally left unset to avoid breaking cross-origin MP file embeds.
+          { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
+          { key: 'Cross-Origin-Resource-Policy', value: 'same-origin' },
           {
             key: 'Strict-Transport-Security',
             value: 'max-age=31536000; includeSubDomains',

--- a/src/components/admin/journey-tools/actions.ts
+++ b/src/components/admin/journey-tools/actions.ts
@@ -2,7 +2,7 @@
 
 import { requireFeatureAccess, loadFeatureAccess, saveFeatureAccess } from "@/lib/authorization";
 import { MPHelper } from "@/lib/providers/ministry-platform";
-import { sanitizeFilterValue, sanitizeIds } from "@/lib/providers/ministry-platform/utils/filter-sanitize";
+import { sanitizeLikeValue, sanitizeIds } from "@/lib/providers/ministry-platform/utils/filter-sanitize";
 import { z } from "zod";
 import {
   loadJourneyToolsConfig,
@@ -66,7 +66,7 @@ export async function getAvailablePrograms(search?: string): Promise<MPProgram[]
   const mp = new MPHelper();
   let filter = "End_Date IS NULL";
   if (search && search.trim()) {
-    filter += ` AND Program_Name LIKE '%${sanitizeFilterValue(search)}%'`;
+    filter += ` AND Program_Name LIKE '%${sanitizeLikeValue(search)}%'`;
   }
   return mp.getTableRecords<MPProgram>({
     table: "Programs",
@@ -87,7 +87,7 @@ export async function getAvailableGroups(search?: string): Promise<MPGroup[]> {
   const mp = new MPHelper();
   let filter = "End_Date IS NULL";
   if (search && search.trim()) {
-    filter += ` AND Group_Name LIKE '%${sanitizeFilterValue(search)}%'`;
+    filter += ` AND Group_Name LIKE '%${sanitizeLikeValue(search)}%'`;
   }
   return mp.getTableRecords<MPGroup>({
     table: "Groups",

--- a/src/components/compliance-processing/compliance-detail-modal.tsx
+++ b/src/components/compliance-processing/compliance-detail-modal.tsx
@@ -101,9 +101,26 @@ function getMpPageId(type: ComplianceChecklistItem["type"]): number | null {
   return pageIds[type];
 }
 
+/**
+ * Returns the URL only if it is a well-formed http(s) URL, else null. The
+ * Background_Checks Report_Url is free-text sourced from a third-party integration;
+ * without a scheme allowlist a value like `javascript:...` would be rendered into an
+ * href. (target=_blank currently blocks execution, but this removes the latent
+ * foot-gun if that attribute is ever dropped or a same-tab nav is added.)
+ */
+function toSafeHttpUrl(url: string): string | null {
+  try {
+    const u = new URL(url);
+    return u.protocol === "http:" || u.protocol === "https:" ? u.href : null;
+  } catch {
+    return null;
+  }
+}
+
 function BackgroundCheckDetailView({ item }: { item: ComplianceChecklistItem }) {
   const bg = item.bgCheckDetail;
   if (!bg) return null;
+  const reportHref = bg.reportUrl ? toSafeHttpUrl(bg.reportUrl) : null;
 
   const rows: { label: string; value: React.ReactNode }[] = [
     { label: "Type", value: bg.typeName || "—" },
@@ -135,9 +152,9 @@ function BackgroundCheckDetailView({ item }: { item: ComplianceChecklistItem }) 
           </React.Fragment>
         ))}
       </div>
-      {bg.reportUrl && (
+      {reportHref && (
         <a
-          href={bg.reportUrl}
+          href={reportHref}
           target="_blank"
           rel="noopener noreferrer"
           className="inline-flex items-center gap-1.5 text-xs text-blue-600 hover:underline mt-1"

--- a/src/components/contact-lookup-details/actions.ts
+++ b/src/components/contact-lookup-details/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { requireFeatureAccess } from '@/lib/authorization';
+import { enforceRateLimit } from '@/lib/rate-limit';
 import { ContactLookupDetails, ContactLogDisplay, ContactLogMadeBy, HouseholdMember, ContactBadges, ContactGroupMembership } from '@/lib/dto';
 import { ContactService } from '@/services/contactService';
 import { ContactLogService } from '@/services/contactLogService';
@@ -10,7 +11,8 @@ import { uploadContactPhoto } from '@/components/shared-actions/processing';
 
 export async function getContactDetails(guid: string): Promise<ContactLookupDetails> {
   try {
-    await requireFeatureAccess("contact-lookup");
+    const session = await requireFeatureAccess("contact-lookup");
+    enforceRateLimit(session.user.id, "search"); // F9: PII reads use the stricter search tier
 
     if (!guid || guid.trim().length === 0) {
       throw new Error('GUID is required');
@@ -32,7 +34,8 @@ export async function getContactDetails(guid: string): Promise<ContactLookupDeta
 
 export async function getContactLogsByContactId(contactId: number): Promise<ContactLogDisplay[]> {
   try {
-    await requireFeatureAccess("contact-lookup");
+    const session = await requireFeatureAccess("contact-lookup");
+    enforceRateLimit(session.user.id, "search"); // F9: PII reads use the stricter search tier
 
     if (!contactId || contactId <= 0) {
       throw new Error('Valid contact ID is required');
@@ -107,7 +110,8 @@ export async function getContactLogsByContactId(contactId: number): Promise<Cont
 
 export async function getHouseholdMembers(householdId: number): Promise<HouseholdMember[]> {
   try {
-    await requireFeatureAccess("contact-lookup");
+    const session = await requireFeatureAccess("contact-lookup");
+    enforceRateLimit(session.user.id, "search"); // F9: PII reads use the stricter search tier
 
     if (!householdId || householdId <= 0) {
       throw new Error('Valid household ID is required');
@@ -123,7 +127,8 @@ export async function getHouseholdMembers(householdId: number): Promise<Househol
 
 export async function getContactBadges(contactId: number, householdPositionId?: number | null): Promise<ContactBadges> {
   try {
-    await requireFeatureAccess("contact-lookup");
+    const session = await requireFeatureAccess("contact-lookup");
+    enforceRateLimit(session.user.id, "search"); // F9: PII reads use the stricter search tier
 
     if (!contactId || contactId <= 0) {
       throw new Error('Valid contact ID is required');
@@ -139,7 +144,8 @@ export async function getContactBadges(contactId: number, householdPositionId?: 
 
 export async function getContactGroups(contactId: number): Promise<ContactGroupMembership[]> {
   try {
-    await requireFeatureAccess("contact-lookup");
+    const session = await requireFeatureAccess("contact-lookup");
+    enforceRateLimit(session.user.id, "search"); // F9: PII reads use the stricter search tier
 
     if (!contactId || contactId <= 0) {
       throw new Error('Valid contact ID is required');

--- a/src/components/shared-actions/processing.ts
+++ b/src/components/shared-actions/processing.ts
@@ -19,6 +19,9 @@ export async function extractValidatedFiles(
       if (!allowedTypes.includes(value.type)) {
         throw new Error(`Invalid file type: ${value.type}. Allowed: JPEG, PNG, GIF, WebP, PDF`);
       }
+      if (value.size > MAX_FILE_SIZE) {
+        throw new Error(`File too large: ${(value.size / 1024 / 1024).toFixed(1)} MB. Maximum ${MAX_FILE_SIZE / 1024 / 1024} MB.`);
+      }
       files.push(value);
     }
   }
@@ -39,6 +42,9 @@ export async function extractValidatedFilesResult(
     if (key === fieldName && value instanceof File && value.size > 0) {
       if (!allowedTypes.includes(value.type)) {
         return { error: `Invalid file type: ${value.type}. Allowed: JPEG, PNG, GIF, WebP, PDF` };
+      }
+      if (value.size > MAX_FILE_SIZE) {
+        return { error: `File too large: ${(value.size / 1024 / 1024).toFixed(1)} MB. Maximum ${MAX_FILE_SIZE / 1024 / 1024} MB.` };
       }
       files.push(value);
     }

--- a/src/components/summer-blast-volunteers/actions.test.ts
+++ b/src/components/summer-blast-volunteers/actions.test.ts
@@ -135,7 +135,7 @@ describe("summer-blast-volunteers actions", () => {
       expect(mockAddToSummerBlast).not.toHaveBeenCalled();
       expect(result.succeededCount).toBe(0);
       expect(result.failures).toHaveLength(2);
-      expect(result.failures[0].error).toBe("Missing required fields");
+      expect(result.failures[0].error).toBe("Invalid or missing IDs");
     });
   });
 });

--- a/src/components/summer-blast-volunteers/actions.ts
+++ b/src/components/summer-blast-volunteers/actions.ts
@@ -70,6 +70,14 @@ export interface BulkAddResult {
 }
 
 /**
+ * Maximum signups accepted in a single bulk-add call. The write rate-limit tier is
+ * charged once per call, and each item performs 2 MP writes, so without this cap a
+ * single request could trigger an unbounded burst of writes (F8). 100 comfortably
+ * covers real batch sizes while bounding the per-call blast radius.
+ */
+const MAX_BULK_ITEMS = 100;
+
+/**
  * Bulk-add multiple signups to Summer Blast as Temp role. Each signup is processed
  * individually so a single failure doesn't abort the batch.
  */
@@ -83,6 +91,15 @@ export async function bulkAddToSummerBlast(
     return { success: false, succeededCount: 0, failures: [] };
   }
 
+  // F8: bound the batch size so one call can't drive an unbounded number of writes.
+  if (items.length > MAX_BULK_ITEMS) {
+    return {
+      success: false,
+      succeededCount: 0,
+      failures: [{ responseId: 0, error: `Too many items in one request (max ${MAX_BULK_ITEMS})` }],
+    };
+  }
+
   const service = SummerBlastService.getInstance();
   const userId = getMpUserId(session);
   const failures: { responseId: number; error: string }[] = [];
@@ -91,8 +108,9 @@ export async function bulkAddToSummerBlast(
   for (const item of items) {
     const contactId = Number(item.contactId);
     const responseId = Number(item.responseId);
-    if (!contactId || !responseId) {
-      failures.push({ responseId: responseId || 0, error: "Missing required fields" });
+    // Require positive integers (service also re-validates via sanitizeId before any filter use).
+    if (!Number.isInteger(contactId) || contactId <= 0 || !Number.isInteger(responseId) || responseId <= 0) {
+      failures.push({ responseId: Number.isInteger(responseId) && responseId > 0 ? responseId : 0, error: "Invalid or missing IDs" });
       continue;
     }
     try {

--- a/src/lib/providers/ministry-platform/utils/filter-sanitize.test.ts
+++ b/src/lib/providers/ministry-platform/utils/filter-sanitize.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { sanitizeFilterValue, sanitizeIds, sanitizeIdsOptional, sanitizeId, sanitizeGuid } from './filter-sanitize';
+import { sanitizeFilterValue, sanitizeLikeValue, sanitizeIds, sanitizeIdsOptional, sanitizeId, sanitizeGuid } from './filter-sanitize';
 
 describe('sanitizeFilterValue', () => {
   it('returns plain strings unchanged', () => {
@@ -16,6 +16,27 @@ describe('sanitizeFilterValue', () => {
 
   it('handles empty string', () => {
     expect(sanitizeFilterValue('')).toBe('');
+  });
+});
+
+describe('sanitizeLikeValue', () => {
+  it('leaves a plain string unchanged', () => {
+    expect(sanitizeLikeValue('Smith')).toBe('Smith');
+  });
+
+  it('doubles single quotes', () => {
+    expect(sanitizeLikeValue("O'Brien")).toBe("O''Brien");
+  });
+
+  it('escapes LIKE wildcards % and _', () => {
+    expect(sanitizeLikeValue('50%')).toBe('50[%]');
+    expect(sanitizeLikeValue('a_b')).toBe('a[_]b');
+  });
+
+  it('escapes the character-class opener [ before adding its own brackets', () => {
+    expect(sanitizeLikeValue('[abc]')).toBe('[[]abc]');
+    // a value with all metacharacters
+    expect(sanitizeLikeValue('%_[')).toBe('[%][_][[]');
   });
 });
 

--- a/src/lib/providers/ministry-platform/utils/filter-sanitize.ts
+++ b/src/lib/providers/ministry-platform/utils/filter-sanitize.ts
@@ -15,6 +15,24 @@ export function sanitizeFilterValue(value: string): string {
 }
 
 /**
+ * Escapes a string for safe use inside a T-SQL LIKE pattern. In addition to the
+ * single-quote escaping done by sanitizeFilterValue, it neutralizes the LIKE
+ * wildcards % and _ and the character-class opener [ by wrapping each in a
+ * character class ([%], [_], [[]), so user input is matched literally and cannot
+ * widen the match or error the query. Use this for `LIKE '%...%'` clauses.
+ *
+ * Escape order matters: '[' is escaped before '%'/'_' so the brackets they add
+ * are not re-escaped.
+ */
+export function sanitizeLikeValue(value: string): string {
+  return value
+    .replace(/'/g, "''")
+    .replace(/\[/g, '[[]')
+    .replace(/%/g, '[%]')
+    .replace(/_/g, '[_]');
+}
+
+/**
  * Validates and joins an array of numeric IDs for use in an IN () clause.
  * Filters out non-finite numbers and values <= 0, then joins with commas.
  * Throws if no valid IDs remain (prevents generating an empty IN () clause).

--- a/src/lib/providers/ministry-platform/utils/http-client.test.ts
+++ b/src/lib/providers/ministry-platform/utils/http-client.test.ts
@@ -113,6 +113,7 @@ describe('HttpClient', () => {
             'Authorization': 'Bearer test-access-token-123',
             'Accept': 'application/json',
           },
+          signal: expect.any(AbortSignal),
         }
       );
       expect(result).toEqual([{ Contact_ID: 1, Display_Name: 'John Doe' }]);
@@ -193,6 +194,7 @@ describe('HttpClient', () => {
             'Accept': 'application/json',
           },
           body: JSON.stringify(newRecord),
+          signal: expect.any(AbortSignal),
         }
       );
       expect(result).toEqual([{ Contact_ID: 1, ...newRecord }]);
@@ -216,6 +218,7 @@ describe('HttpClient', () => {
             'Accept': 'application/json',
           },
           body: undefined,
+          signal: expect.any(AbortSignal),
         }
       );
     });
@@ -269,6 +272,7 @@ describe('HttpClient', () => {
             // No Content-Type for FormData
           },
           body: formData,
+          signal: expect.any(AbortSignal),
         }
       );
       expect(result).toEqual({ FileId: 1 });
@@ -308,6 +312,7 @@ describe('HttpClient', () => {
             'Accept': 'application/json',
           },
           body: JSON.stringify(updatedRecord),
+          signal: expect.any(AbortSignal),
         }
       );
       expect(result).toEqual([updatedRecord]);
@@ -348,6 +353,7 @@ describe('HttpClient', () => {
             'Accept': 'application/json',
           },
           body: formData,
+          signal: expect.any(AbortSignal),
         }
       );
       expect(result).toEqual({ FileId: 1, FileName: 'updated.txt' });
@@ -371,6 +377,7 @@ describe('HttpClient', () => {
             'Authorization': 'Bearer test-access-token-123',
             'Accept': 'application/json',
           },
+          signal: expect.any(AbortSignal),
         }
       );
       expect(result).toEqual([{ Contact_ID: 1 }]);

--- a/src/lib/providers/ministry-platform/utils/http-client.ts
+++ b/src/lib/providers/ministry-platform/utils/http-client.ts
@@ -1,5 +1,11 @@
 import { QueryParams, RequestBody } from "../types/provider.types";
 
+/**
+ * Abort outbound MP requests that hang. Without an upper bound, a slow or stuck
+ * upstream can pin the shared service-account request path indefinitely (F13).
+ */
+const REQUEST_TIMEOUT_MS = 30_000;
+
 export class HttpClient {
     private baseUrl: string;
     private getToken: () => string;
@@ -17,18 +23,25 @@ export class HttpClient {
             headers: {
                 'Authorization': `Bearer ${this.getToken()}`,
                 'Accept': 'application/json'
-            }
+            },
+            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
         });
 
         if (!response.ok) {
-            let errorDetails = '';
-            try {
-                const errorBody = await response.text();
-                errorDetails = errorBody ? ` - ${errorBody}` : '';
-            } catch {
-                // If we can't read the error body, just continue without it
+            // SECURITY (F6): never put the response body in the thrown error. MP echoes
+            // the request (including $filter values such as searched emails/phones/
+            // GUIDs/DOB) in error bodies, and this message propagates to ~40
+            // console.error sites — it would leak PII to production logs. In
+            // development only, surface the body to aid debugging.
+            if (process.env.NODE_ENV === 'development') {
+                try {
+                    const errorBody = await response.text();
+                    if (errorBody) console.warn(`[MP GET ${endpoint}] error body:`, errorBody);
+                } catch {
+                    // ignore — body is best-effort in dev
+                }
             }
-            throw new Error(`GET ${endpoint} failed: ${response.status} ${response.statusText}${errorDetails}`);
+            throw new Error(`GET ${endpoint} failed: ${response.status} ${response.statusText}`);
         }
 
         return await response.json() as T;
@@ -44,7 +57,8 @@ export class HttpClient {
                 'Content-Type': 'application/json',
                 'Accept': 'application/json'
             },
-            body: body ? JSON.stringify(body) : undefined
+            body: body ? JSON.stringify(body) : undefined,
+            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
         });
 
         if (!response.ok) {
@@ -64,7 +78,8 @@ export class HttpClient {
                 'Accept': 'application/json'
                 // Don't set Content-Type for FormData
             },
-            body: formData
+            body: formData,
+            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
         });
 
         if (!response.ok) {
@@ -84,7 +99,8 @@ export class HttpClient {
                 'Content-Type': 'application/json',
                 'Accept': 'application/json'
             },
-            body: JSON.stringify(body)
+            body: JSON.stringify(body),
+            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
         });
 
         if (!response.ok) {
@@ -104,7 +120,8 @@ export class HttpClient {
                 'Accept': 'application/json'
                 // Don't set Content-Type for FormData
             },
-            body: formData
+            body: formData,
+            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
         });
 
         if (!response.ok) {
@@ -122,7 +139,8 @@ export class HttpClient {
             headers: {
                 'Authorization': `Bearer ${this.getToken()}`,
                 'Accept': 'application/json'
-            }
+            },
+            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
         });
 
         if (!response.ok) {

--- a/src/services/contactService.test.ts
+++ b/src/services/contactService.test.ts
@@ -19,6 +19,9 @@ vi.mock('@/lib/providers/ministry-platform', () => {
 
 vi.mock('@/lib/providers/ministry-platform/utils/filter-sanitize', () => ({
   sanitizeFilterValue: vi.fn((v: string) => v.replace(/'/g, "''")),
+  sanitizeLikeValue: vi.fn((v: string) =>
+    v.replace(/'/g, "''").replace(/\[/g, '[[]').replace(/%/g, '[%]').replace(/_/g, '[_]')
+  ),
   sanitizeGuid: vi.fn((v: string) => {
     if (!/^[0-9a-f-]{36}$/i.test(v)) throw new Error('Invalid GUID format');
     return v;

--- a/src/services/contactService.ts
+++ b/src/services/contactService.ts
@@ -1,6 +1,6 @@
 import { ContactSearch, ContactLookupDetails, HouseholdMember, ContactBadges, ContactGroupMembership } from "@/lib/dto";
 import { MPHelper } from "@/lib/providers/ministry-platform";
-import { sanitizeFilterValue, sanitizeGuid, sanitizeIds } from "@/lib/providers/ministry-platform/utils/filter-sanitize";
+import { sanitizeLikeValue, sanitizeGuid, sanitizeIds } from "@/lib/providers/ministry-platform/utils/filter-sanitize";
 
 /**
  * ContactService - Singleton service for managing contact-related operations
@@ -43,7 +43,7 @@ export class ContactService {
    * @returns Promise<ContactSearch[]> - Array of matching contacts (limited to 20 results)
    */
   public async contactSearch(search: string): Promise<ContactSearch[]> {
-    const safe = sanitizeFilterValue(search);
+    const safe = sanitizeLikeValue(search);
     const records = await this.mp!.getTableRecords<ContactSearch>({
       table: "Contacts",
       filter: `First_Name LIKE '%${safe}%' OR Last_Name LIKE '%${safe}%' OR Nickname LIKE '%${safe}%' OR Email_Address LIKE '%${safe}%' OR Mobile_Phone LIKE '%${safe}%'`,


### PR DESCRIPTION
## Summary

Second batch of fixes from the [2026-06-23 security audit](.claude/notes/security-audit-2026-06-23.md), covering the deferred lower-severity findings. **Stacked on #185** (base = `security/idor-injection-redirect-hardening`) — review/merge #185 first; once it merges this PR's diff narrows to just these changes.

## Security Review

| ID | Severity | Fix |
|----|----------|-----|
| **F6** | MEDIUM | `HttpClient` GET no longer puts the MP error-response body (echoes `$filter` PII) in `Error.message`; dev-only `console.warn`. Stops PII reaching the ~40 `console.error` sinks. |
| **F8** | MEDIUM | `bulkAddToSummerBlast` caps the batch at **100** items + validates each ID as a positive integer. |
| **F9** | LOW | Contact PII-read actions now enforce the `search` tier (30/min) instead of the default 120/min. |
| **F13** | LOW | All outbound MP fetches use `AbortSignal.timeout(30s)`. |
| **F14** | LOW | Added `Cross-Origin-Opener-Policy` + `Cross-Origin-Resource-Policy: same-origin` (COEP left unset to preserve MP file embeds). |
| **F15** | LOW | New `sanitizeLikeValue()` escapes T-SQL LIKE wildcards (`% _ [`); applied to journey-tools admin search + contact search. |
| **Latent** | — | Background-check `Report_Url` now passes an http(s) scheme allowlist (`toSafeHttpUrl`) before use as an `href`. |
| **F7** | LOW | **Partial** — upload validators now enforce `MAX_FILE_SIZE` (was imported but unused). The `upload`-tier reassignment is deferred. |

**Still open (next batch):** F2 (per-record scope authorization — HIGH, needs runtime verification), F7 upload-tier, F10 (year/cache cap), F11 (admin page server gate), F12 (authz TTL), F16 (aggregate rate cap).

## Test changes
- `filter-sanitize.test.ts` — `sanitizeLikeValue` tests; `http-client.test.ts` — assert the timeout `signal`; `contactService.test.ts` — added `sanitizeLikeValue` to the `filter-sanitize` mock; `summer-blast` test — updated to the new validation message.

## Validation
- ✅ `npm run test:run` — **521 passing**
- ✅ `npm run lint` — clean
- ℹ️ `npx tsc --noEmit` — 16 errors, all pre-existing test-fixture issues, **unchanged vs base**; none reference files in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PJ9LNFjCq2MDCREYQZcDE
