### PR TITLE
security: enforce 'upload' rate-limit tier on document uploads (F7)

### DIFF
--- a/src/components/compliance-processing/actions.ts
+++ b/src/components/compliance-processing/actions.ts
@@ -74,6 +74,8 @@ export async function createComplianceMilestone(slug: string, formData: FormData
     const files = await extractValidatedFiles(formData);
 
     if (files.length > 0) {
+      // F7: file uploads are bounded by the dedicated, stricter 'upload' tier
+      enforceRateLimit(session.user.id, "upload");
       await service.uploadDocument('Participant_Milestones', newMilestoneId, files, userId);
     }
   } catch (error) {
@@ -98,6 +100,8 @@ export async function createComplianceCertification(slug: string, formData: Form
 
     const files = await extractValidatedFiles(formData);
     if (files.length > 0) {
+      // F7: file uploads are bounded by the dedicated, stricter 'upload' tier
+      enforceRateLimit(session.user.id, "upload");
       await service.uploadDocument('Participant_Certifications', newCertId, files, userId);
     }
   } catch (error) {
@@ -121,6 +125,8 @@ export async function createComplianceFormResponse(slug: string, formData: FormD
 
     const files = await extractValidatedFiles(formData);
     if (files.length > 0) {
+      // F7: file uploads are bounded by the dedicated, stricter 'upload' tier
+      enforceRateLimit(session.user.id, "upload");
       await service.uploadDocument('Form_Responses', newFormResponseId, files, userId);
     }
   } catch (error) {
@@ -152,6 +158,8 @@ export async function updateComplianceMilestone(slug: string, formData: FormData
     if ("error" in result) return { success: false, error: result.error };
 
     if (result.files.length > 0) {
+      // F7: file uploads are bounded by the dedicated, stricter 'upload' tier
+      enforceRateLimit(session.user.id, "upload");
       await service.uploadDocument('Participant_Milestones', milestoneRecordId, result.files, userId);
     }
 

--- a/src/components/journey-processing/actions.ts
+++ b/src/components/journey-processing/actions.ts
@@ -86,6 +86,8 @@ export async function createJourneyMilestone(slug: string, formData: FormData): 
     const files = await extractValidatedFiles(formData);
 
     if (files.length > 0) {
+      // F7: file uploads are bounded by the dedicated, stricter 'upload' tier
+      enforceRateLimit(session.user.id, "upload");
       await service.uploadDocument('Participant_Milestones', newMilestoneId, files, userId);
     }
   } catch (error) {
@@ -117,6 +119,8 @@ export async function updateJourneyMilestone(slug: string, formData: FormData): 
     if ("error" in result) return { success: false, error: result.error };
 
     if (result.files.length > 0) {
+      // F7: file uploads are bounded by the dedicated, stricter 'upload' tier
+      enforceRateLimit(session.user.id, "upload");
       await service.uploadDocument('Participant_Milestones', milestoneRecordId, result.files, userId);
     }
 


### PR DESCRIPTION
## Summary

Completes **F7** from the [2026-06-23 audit](.claude/notes/security-audit-2026-06-23.md) — the **`upload` rate-limit tier** on document uploads. (The `MAX_FILE_SIZE` half landed in #186; this is the remaining tier reassignment, done as its own PR per request.)

**Standalone — branched off `main`, independent of #185/#186** (touches only the journey/compliance processing actions, which those PRs don't modify), so it can merge in any order.

## Security Review

The six document-upload server actions charged only the `write` tier (30/min). File attachments now additionally consume the dedicated **`upload`** tier (10 / 10 min), matching the photo-upload path — but the charge is applied **only when a file is actually present**, so milestone/certification/form creates without an attachment keep working under the normal `write` budget.

Actions updated:
- `createJourneyMilestone`, `updateJourneyMilestone`
- `createComplianceMilestone`, `createComplianceCertification`, `createComplianceFormResponse`, `updateComplianceMilestone`

## Validation
- ✅ `npm run test:run` — 509 passing
- ✅ `npm run lint` — clean
- ℹ️ `npx tsc --noEmit` — 16 errors, all pre-existing test-fixture issues, unchanged; none in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PJ9LNFjCq2MDCREYQZcDE
