### PR TITLE
security: low-severity hardening (F10 cache/year, F11 admin gate, F16 rate-limit clarity)

### DIFF
--- a/src/app/(web)/admin/layout.tsx
+++ b/src/app/(web)/admin/layout.tsx
@@ -1,0 +1,35 @@
+import { connection } from "next/server";
+import { redirect } from "next/navigation";
+import { requireFeatureAccess } from "@/lib/authorization";
+
+/**
+ * Server-side access gate for the entire /admin subtree (F11).
+ *
+ * The proxy only checks for the *presence* of a session cookie, and while every
+ * admin server action already enforces `requireFeatureAccess("admin")`, the admin
+ * UI shell itself rendered for any authenticated user. This layout enforces admin
+ * access before the page renders and redirects non-admins home, so page access —
+ * not just actions — is gated. Admin status is derived server-side from MP User
+ * Groups, so it cannot be spoofed by the client.
+ */
+export default async function AdminLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  // Defer to request time — requireFeatureAccess reads headers() and queries MP,
+  // so this segment must not be statically prerendered (Cache Components / PPR).
+  await connection();
+
+  let allowed = false;
+  try {
+    await requireFeatureAccess("admin");
+    allowed = true;
+  } catch {
+    // Unauthenticated or non-admin — fall through to redirect. (Keep redirect()
+    // OUT of the try/catch: it signals via a thrown control-flow error.)
+    allowed = false;
+  }
+
+  if (!allowed) redirect("/");
+
+  return <>{children}</>;
+}

--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -24,8 +24,10 @@ export async function getDashboardMetrics(
   year?: number
 ): Promise<DashboardData> {
   await requireFeatureAccess("dashboard");
-  const currentYear = year || getCurrentMinistryYear();
-  return getCachedDashboardData(currentYear);
+  // F10: clamp the client-supplied year to a sane integer range before it becomes a
+  // cache key, so it can't generate unbounded distinct cache entries / MP load.
+  const safeYear = sanitizeMinistryYear(year);
+  return getCachedDashboardData(safeYear);
 }
 
 /**
@@ -96,6 +98,20 @@ function getCurrentMinistryYear(): number {
   return currentMonth >= 8
     ? today.getFullYear()
     : today.getFullYear() - 1;
+}
+
+/**
+ * Clamps a client-supplied ministry year to a valid integer within a sane window
+ * (currentYear-10 .. currentYear+1). Anything non-integer or out of range falls
+ * back to the current ministry year. Server-action args arrive as untrusted wire
+ * data, so a value typed `number` can actually be a string or fractional value —
+ * this prevents unbounded cache-key / MP-load growth (F10).
+ */
+function sanitizeMinistryYear(year: number | undefined): number {
+  const current = getCurrentMinistryYear();
+  if (typeof year !== "number" || !Number.isInteger(year)) return current;
+  if (year < current - 10 || year > current + 1) return current;
+  return year;
 }
 
 /**

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -17,7 +17,18 @@ interface RateLimitConfig {
   windowMs: number;
 }
 
-/** Rate limit tiers — applied per authenticated user */
+/**
+ * Rate limit tiers — applied per authenticated user.
+ *
+ * NOTE (F16): the `general` tier is enforced on EVERY server action via
+ * requireSession() (which requireFeatureAccess() also calls), so it acts as the
+ * universal per-user throughput gate — total server-action calls per user are
+ * bounded by `general` (120/min). The `write`/`upload`/`search` tiers are stricter
+ * *sub-caps* on those operation classes; they are NOT additional budget stacked on
+ * top of `general` (a write action consumes one `general` unit AND one `write`
+ * unit). Any future endpoint that bypasses requireSession (e.g. a new
+ * unauthenticated route) must add its own limiter, ideally IP-keyed.
+ */
 export const RATE_LIMITS = {
   /** General server action calls (reads, navigation) — 120 per minute */
   general: { limit: 120, windowMs: 60_000 },

--- a/src/lib/service-cache.test.ts
+++ b/src/lib/service-cache.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { serviceCache } from './service-cache';
+
+const noopFetcher = async () => undefined;
+
+describe('serviceCache entry cap (F10)', () => {
+  it('evicts the oldest entries once the max cap is exceeded', () => {
+    // Insert well beyond the cap (MAX_ENTRIES = 500). These are inserted last, so
+    // the surviving entries are the most-recent 500 — i.e. our later keys remain
+    // and our earliest keys are evicted, regardless of any pre-existing entries.
+    const N = 600;
+    for (let i = 0; i < N; i++) {
+      serviceCache.set(`evict-test:${i}`, i);
+    }
+
+    // Earliest key evicted...
+    expect(serviceCache.get('evict-test:0', 60_000, noopFetcher)).toBeUndefined();
+    // ...most-recent key retained.
+    expect(serviceCache.get(`evict-test:${N - 1}`, 60_000, noopFetcher)).toBe(N - 1);
+
+    serviceCache.deleteByPrefix('evict-test:');
+  });
+
+  it('re-setting a key keeps it as most-recent (not immediately evicted)', () => {
+    serviceCache.set('keepalive:anchor', 'v1');
+    // Push the cap so eviction runs on subsequent sets.
+    for (let i = 0; i < 600; i++) {
+      serviceCache.set(`keepalive:${i}`, i);
+      // Continuously refresh the anchor so it stays at the most-recent end.
+      serviceCache.set('keepalive:anchor', 'v2');
+    }
+    expect(serviceCache.get('keepalive:anchor', 60_000, noopFetcher)).toBe('v2');
+
+    serviceCache.deleteByPrefix('keepalive:');
+  });
+});

--- a/src/lib/service-cache.ts
+++ b/src/lib/service-cache.ts
@@ -20,6 +20,13 @@ interface CacheEntry<T = unknown> {
 class ServiceCache {
   private store = new Map<string, CacheEntry>();
   private refreshing = new Set<string>();
+  /**
+   * Upper bound on distinct cache entries. The app's known cached functions use a
+   * small, fixed set of keys, so this only ever trips if keys are derived from
+   * unvalidated input — it bounds memory growth from that (F10). Eviction is FIFO
+   * by insertion order (re-inserting on each set keeps recently-written keys last).
+   */
+  private static readonly MAX_ENTRIES = 500;
 
   /**
    * Get cached data if available. Returns undefined if key has never been set.
@@ -49,7 +56,21 @@ class ServiceCache {
    * Store data with current timestamp.
    */
   set<T>(key: string, data: T): void {
+    // Re-insert so the just-written key moves to the end (most-recent) — keeps the
+    // FIFO eviction below from immediately dropping a freshly-set existing key.
+    this.store.delete(key);
     this.store.set(key, { data, timestamp: Date.now() });
+
+    // F10: bound total entries; evict the oldest (front of insertion order).
+    if (this.store.size > ServiceCache.MAX_ENTRIES) {
+      let toRemove = this.store.size - ServiceCache.MAX_ENTRIES;
+      for (const k of this.store.keys()) {
+        if (toRemove <= 0) break;
+        this.store.delete(k);
+        this.refreshing.delete(k);
+        toRemove--;
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Third batch from the [2026-06-23 audit](.claude/notes/security-audit-2026-06-23.md) — the safe **LOW** findings. **Standalone, off `main`**, independent of #185/#186/#187 (different files).

## Security Review

| ID | Fix |
|----|-----|
| **F10** | `getDashboardMetrics` clamps the client `year` to an integer in `[currentYear-10, currentYear+1]` (falls back to current) before it becomes a cache key; `ServiceCache` now caps entries at **500** with FIFO eviction. Stops unbounded cache-key / MP-load growth from a varied `year`. |
| **F11** | New async server-component layout for `/admin` enforces `requireFeatureAccess("admin")` and redirects non-admins. The proxy only checks cookie presence and admin *actions* were already gated, but the admin UI shell rendered for any authenticated user — this gates page access too (admin status derived server-side from MP groups, non-spoofable). |
| **F16** | **Clarification (no behavior change).** `general` is enforced on every server action via `requireSession()`, so it's the universal per-user throughput gate (120/min total); `write`/`upload`/`search` are stricter *sub-caps*, not additive budget. The audit's "~180 ops/min" double-counted (a write also consumes a `general` unit). Documented in `rate-limit.ts`, plus a note that any future unauthenticated route must add its own (IP-keyed) limiter. |

## Changes
- `src/components/dashboard/actions.ts` — `sanitizeMinistryYear()` clamp
- `src/lib/service-cache.ts` — entry cap + FIFO eviction (+ `service-cache.test.ts`)
- `src/app/(web)/admin/layout.tsx` — **new** admin access gate
- `src/lib/rate-limit.ts` — F16 doc clarification

## Validation
- ✅ `npm run test:run` — **511 passing** (+2 new)
- ✅ `npm run lint` — clean
- ℹ️ `npx tsc --noEmit` — 16 errors, all pre-existing test-fixture issues, unchanged; none in changed files.
- ℹ️ `npm run build` not run locally (needs runtime MP env). The `/admin` layout uses `connection()` + a Suspense-wrapped parent, matching the project's documented PPR pattern — worth confirming in CI's build step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PJ9LNFjCq2MDCREYQZcDE
