### PR TITLE
security: per-record participant scope authorization (F2) [needs runtime test]

### DIFF
--- a/.claude/notes/security-audit-2026-06-23.md
+++ b/.claude/notes/security-audit-2026-06-23.md
@@ -34,7 +34,7 @@ All MP API calls run as a **single shared client-credentials service account wit
 | # | Finding | Severity | Category | Status |
 |---|---------|----------|----------|--------|
 | F1 | Filter injection + IDOR via unvalidated numeric IDs | **HIGH** | Injection / Broken Access Control | ✅ Injection fixed (PR); IDOR scope → F2 |
-| F2 | Cross-participant writes (journey/compliance) accept arbitrary IDs | **HIGH** | Broken Access Control | ⚠️ Partial (PR) — scope check deferred (TODO) |
+| F2 | Cross-participant reads/writes (journey/compliance) accept arbitrary IDs | **HIGH** | Broken Access Control | ✅ Fixed (follow-up PR) — per-record scope enforcement w/ enforce\|report toggle; Zod-on-writes still open |
 | F3 | `deleteContactLog` has no ownership check | **HIGH** | Broken Access Control | ✅ Fixed (PR) |
 | F4 | User-profile actions accept an arbitrary GUID | **HIGH** | Broken Access Control | ✅ Fixed (PR) |
 | F5 | Open redirect via backslash bypass of `getSafeCallbackUrl` | **MEDIUM** | Redirect | ✅ Fixed (PR) |

--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,14 @@ NEXT_PUBLIC_APP_NAME=MP Tools
 # Users in ANY of these groups have full access to all features + admin page
 ADMIN_USER_GROUP_IDS=29
 
+# Per-record scope enforcement for journey/compliance tools (F2)
+# Controls whether a user may only read/write participants within a tool's scope.
+#   enforce (default, or unset) — block out-of-scope access (throws "Forbidden")
+#   report                       — log would-be denials ("[scope:report] ...") but
+#                                  ALLOW them; use to validate the scope logic
+#                                  against real data before turning on enforcement.
+# F2_SCOPE_ENFORCEMENT=enforce
+
 # GitHub Feedback Configuration
 # PAT with `repo` or `public_repo` scope — required for the feedback feature
 # Generate at: https://github.com/settings/tokens

--- a/src/lib/scope-enforcement.test.ts
+++ b/src/lib/scope-enforcement.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getScopeMode, enforceScope } from './scope-enforcement';
+
+const ORIGINAL = process.env.F2_SCOPE_ENFORCEMENT;
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.F2_SCOPE_ENFORCEMENT;
+  else process.env.F2_SCOPE_ENFORCEMENT = ORIGINAL;
+  vi.restoreAllMocks();
+});
+
+describe('scope-enforcement', () => {
+  it('defaults to enforce mode when unset', () => {
+    delete process.env.F2_SCOPE_ENFORCEMENT;
+    expect(getScopeMode()).toBe('enforce');
+  });
+
+  it('reads report mode from the env var', () => {
+    process.env.F2_SCOPE_ENFORCEMENT = 'report';
+    expect(getScopeMode()).toBe('report');
+  });
+
+  it('treats any non-"report" value as enforce', () => {
+    process.env.F2_SCOPE_ENFORCEMENT = 'something-else';
+    expect(getScopeMode()).toBe('enforce');
+  });
+
+  it('allows an in-scope decision without throwing', () => {
+    delete process.env.F2_SCOPE_ENFORCEMENT;
+    expect(() => enforceScope(true, 'ctx')).not.toThrow();
+  });
+
+  it('throws "Forbidden" on out-of-scope in enforce mode', () => {
+    delete process.env.F2_SCOPE_ENFORCEMENT;
+    expect(() => enforceScope(false, 'participant 5')).toThrow(/Forbidden/);
+  });
+
+  it('warns but allows out-of-scope in report mode', () => {
+    process.env.F2_SCOPE_ENFORCEMENT = 'report';
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(() => enforceScope(false, 'participant 5')).not.toThrow();
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/scope-enforcement.ts
+++ b/src/lib/scope-enforcement.ts
@@ -1,0 +1,35 @@
+/**
+ * Per-record scope enforcement (F2).
+ *
+ * `requireFeatureAccess` proves a user may USE a journey/compliance tool, but not
+ * that a specific participant/record belongs to that tool. Without a per-record
+ * check, a user of one tool can read or write another tool's participants by
+ * passing a different (valid) ID. The journey/compliance services resolve the set
+ * of participants each tool legitimately manages and gate access through the
+ * helper below.
+ *
+ * Rollout safety — `F2_SCOPE_ENFORCEMENT` env var:
+ *   - unset / "enforce" (default): out-of-scope access throws "Forbidden".
+ *   - "report": the would-be denial is logged but ALLOWED. Use this to validate
+ *     the scope logic against real data first (watch for false denials in logs),
+ *     then switch to enforce.
+ */
+export type ScopeMode = "enforce" | "report";
+
+export function getScopeMode(): ScopeMode {
+  return process.env.F2_SCOPE_ENFORCEMENT === "report" ? "report" : "enforce";
+}
+
+/**
+ * Gate an access decision. In enforce mode, throws when `inScope` is false; in
+ * report mode, logs the would-be denial and allows it. `context` must contain only
+ * non-PII identifiers (e.g. numeric IDs) since it may be logged.
+ */
+export function enforceScope(inScope: boolean, context: string): void {
+  if (inScope) return;
+  if (getScopeMode() === "report") {
+    console.warn(`[scope:report] would deny out-of-scope access — ${context}`);
+    return;
+  }
+  throw new Error("Forbidden: record is not in scope for this tool");
+}

--- a/src/services/complianceProcessingService.ts
+++ b/src/services/complianceProcessingService.ts
@@ -12,6 +12,7 @@ import {
 } from '@/lib/dto';
 import { getComplianceToolBySlug, type ComplianceToolConfig } from '@/lib/compliance-tools-config';
 import { nowCentral } from '@/lib/processing-utils';
+import { enforceScope } from '@/lib/scope-enforcement';
 
 const BATCH_SIZE = 100;
 const EXPIRING_SOON_DAYS = 30;
@@ -124,6 +125,91 @@ export class ComplianceProcessingService {
   }
 
   // ---------------------------------------------------------------
+  // Per-record scope authorization (F2)
+  // ---------------------------------------------------------------
+
+  /**
+   * Resolves the set of Participant_IDs this compliance tool legitimately manages
+   * — the same population getParticipants()/getPausedParticipants() surface. Used
+   * to gate per-record access so a user of one tool cannot read or write another
+   * tool's participants by passing a different (valid) ID. Mirrors the discovery
+   * filters in getParticipantsForGroup / getParticipantsByGroupRole.
+   */
+  private async getScopedParticipantIds(): Promise<Set<number>> {
+    const ids = new Set<number>();
+    const now = nowCentral();
+    const { trackingGroupId, pausedGroupId, supportsPause, groupRoleIds } = this.config;
+
+    if (trackingGroupId) {
+      const groupIds = [trackingGroupId];
+      if (supportsPause && pausedGroupId) groupIds.push(pausedGroupId);
+      const rows = await this.mp.getTableRecords<{ Participant_ID: number }>({
+        table: 'Group_Participants',
+        select: 'Participant_ID',
+        filter: `Group_ID IN (${sanitizeIds(groupIds)}) AND (End_Date IS NULL OR End_Date >= '${now}')`,
+      });
+      for (const r of rows) ids.add(r.Participant_ID);
+      return ids;
+    }
+
+    // Group-role mode: members holding any of the configured group roles (mirrors
+    // getParticipantsByGroupRole).
+    if (groupRoleIds.length > 0) {
+      for (let i = 0; i < groupRoleIds.length; i += BATCH_SIZE) {
+        const batch = groupRoleIds.slice(i, i + BATCH_SIZE);
+        const rows = await this.mp.getTableRecords<{ Participant_ID: number }>({
+          table: 'Group_Participants',
+          select: 'Participant_ID',
+          filter: `Group_Role_ID IN (${sanitizeIds(batch)}) AND Start_Date <= '${now}' AND (End_Date IS NULL OR End_Date >= '${now}')`,
+        });
+        for (const r of rows) ids.add(r.Participant_ID);
+      }
+    }
+    return ids;
+  }
+
+  /** Throw/report (per F2_SCOPE_ENFORCEMENT) if the participant is not in tool scope. */
+  private async assertParticipantInScope(participantId: number): Promise<void> {
+    const scoped = await this.getScopedParticipantIds();
+    enforceScope(scoped.has(participantId), `participant ${participantId} outside this compliance tool`);
+  }
+
+  /** Assert scope for a contact by resolving its participant record(s). */
+  private async assertContactInScope(contactId: number): Promise<void> {
+    const parts = await this.mp.getTableRecords<{ Participant_ID: number }>({
+      table: 'Participants',
+      select: 'Participant_ID',
+      filter: `Contact_ID = ${sanitizeId(contactId)}`,
+    });
+    const scoped = await this.getScopedParticipantIds();
+    enforceScope(parts.some(p => scoped.has(p.Participant_ID)), `contact ${contactId} outside this compliance tool`);
+  }
+
+  /** Resolve a Group_Participant record to its Participant_ID, then assert scope. */
+  private async assertGroupParticipantInScope(groupParticipantId: number): Promise<void> {
+    const rows = await this.mp.getTableRecords<{ Participant_ID: number }>({
+      table: 'Group_Participants',
+      select: 'Participant_ID',
+      filter: `Group_Participant_ID = ${sanitizeId(groupParticipantId)}`,
+      top: 1,
+    });
+    if (!rows[0]) { enforceScope(false, `group-participant ${groupParticipantId} not found`); return; }
+    await this.assertParticipantInScope(rows[0].Participant_ID);
+  }
+
+  /** Resolve a Participant_Milestone record to its Participant_ID, then assert scope. */
+  private async assertMilestoneRecordInScope(participantMilestoneId: number): Promise<void> {
+    const rows = await this.mp.getTableRecords<{ Participant_ID: number }>({
+      table: 'Participant_Milestones',
+      select: 'Participant_ID',
+      filter: `Participant_Milestone_ID = ${sanitizeId(participantMilestoneId)}`,
+      top: 1,
+    });
+    if (!rows[0]) { enforceScope(false, `milestone ${participantMilestoneId} not found`); return; }
+    await this.assertParticipantInScope(rows[0].Participant_ID);
+  }
+
+  // ---------------------------------------------------------------
   // Discontinue / Complete badge logic
   // ---------------------------------------------------------------
 
@@ -187,12 +273,10 @@ export class ComplianceProcessingService {
     contactId = sanitizeId(contactId);
     participantId = sanitizeId(participantId);
     groupParticipantId = sanitizeId(groupParticipantId);
-    // SECURITY TODO(F2): per-record authorization. requireFeatureAccess only verifies
-    // the user may use this compliance feature, not that this specific participant is
-    // in scope for it. A user with access to one compliance tool could read another
-    // participant's detail (incl. background-check/compliance data) by passing a
-    // different (valid) ID. Verify participantId/contactId belongs to this tool's
-    // tracking group / group-roles before returning PII. Tracked follow-up.
+    // SECURITY (F2): per-record authorization. requireFeatureAccess only proves the
+    // user may use this compliance tool, not that this participant belongs to it —
+    // verify scope before returning any PII (incl. background-check/compliance data).
+    await this.assertParticipantInScope(participantId);
     const contacts = await this.mp.getTableRecords<ContactRecord>({
       table: 'Contacts',
       select: 'Contact_ID,First_Name,Nickname,Last_Name,dp_fileUniqueId AS Image_GUID,Email_Address,Mobile_Phone',
@@ -288,6 +372,8 @@ export class ComplianceProcessingService {
     Date_Accomplished?: string;
     Notes?: string;
   }, userId?: number): Promise<number> {
+    // SECURITY (F2): only write milestones for participants this tool manages.
+    await this.assertParticipantInScope(data.Participant_ID);
     // Check if this milestone is configured to discontinue the journey
     const milestoneConfig = this.config.journeyMilestones.find(m => m.milestoneId === data.Milestone_ID);
     const discontinueJourney = milestoneConfig?.discontinuesJourney === true;
@@ -312,6 +398,8 @@ export class ComplianceProcessingService {
     Date_Accomplished?: string;
     Notes?: string;
   }, userId?: number): Promise<void> {
+    // SECURITY (F2): the milestone record must belong to a participant in this tool.
+    await this.assertMilestoneRecordInScope(data.Participant_Milestone_ID);
     const record: Record<string, unknown> = {
       Participant_Milestone_ID: data.Participant_Milestone_ID,
     };
@@ -327,6 +415,8 @@ export class ComplianceProcessingService {
     Certification_Completed: string;
     Notes?: string;
   }, userId?: number): Promise<number> {
+    // SECURITY (F2): only write certifications for participants this tool manages.
+    await this.assertParticipantInScope(data.Participant_ID);
     const record: Record<string, unknown> = {
       Participant_ID: data.Participant_ID,
       Certification_Type_ID: data.Certification_Type_ID,
@@ -347,6 +437,8 @@ export class ComplianceProcessingService {
     Contact_ID: number;
     Response_Date: string;
   }, userId?: number): Promise<number> {
+    // SECURITY (F2): the contact must map to a participant this tool manages.
+    await this.assertContactInScope(data.Contact_ID);
     const record: Record<string, unknown> = {
       Form_ID: data.Form_ID,
       Contact_ID: data.Contact_ID,
@@ -374,6 +466,9 @@ export class ComplianceProcessingService {
       throw new Error('Complete requires a tracking group');
     }
 
+    // SECURITY (F2): the group-participant record must belong to this tool.
+    await this.assertGroupParticipantInScope(currentGroupParticipantId);
+
     const now = nowCentral();
     await this.mp.updateTableRecords(
       'Group_Participants',
@@ -397,6 +492,8 @@ export class ComplianceProcessingService {
     }
 
     const { participantId, currentGroupParticipantId, notes, userId } = params;
+    // SECURITY (F2): only pause participants this tool manages.
+    await this.assertParticipantInScope(participantId);
     const { pausedGroupId, pauseMilestoneId, programId, defaultGroupRoleId } = this.config;
 
     if (!pausedGroupId || !pauseMilestoneId || !programId || !defaultGroupRoleId) {
@@ -439,6 +536,8 @@ export class ComplianceProcessingService {
     }
 
     const { participantId, currentGroupParticipantId, userId } = params;
+    // SECURITY (F2): only resume participants this tool manages.
+    await this.assertParticipantInScope(participantId);
     const { trackingGroupId, defaultGroupRoleId } = this.config;
 
     if (!trackingGroupId || !defaultGroupRoleId) {

--- a/src/services/journeyProcessingService.ts
+++ b/src/services/journeyProcessingService.ts
@@ -11,6 +11,7 @@ import {
 } from '@/lib/dto';
 import { getJourneyToolBySlug, type JourneyToolConfig } from '@/lib/journey-tools-config';
 import { nowCentral } from '@/lib/processing-utils';
+import { enforceScope } from '@/lib/scope-enforcement';
 
 const BATCH_SIZE = 100;
 
@@ -79,6 +80,81 @@ export class JourneyProcessingService {
     } else {
       this.instances.clear();
     }
+  }
+
+  // ---------------------------------------------------------------
+  // Per-record scope authorization (F2)
+  // ---------------------------------------------------------------
+
+  /**
+   * Resolves the set of Participant_IDs this journey tool legitimately manages —
+   * the same population getParticipants()/getPausedParticipants() surface. Used to
+   * gate per-record access so a user of one tool cannot read or write another
+   * tool's participants by passing a different (valid) ID. Mirrors the discovery
+   * filters in getParticipantsForGroup / getParticipantsFromMilestones.
+   */
+  private async getScopedParticipantIds(): Promise<Set<number>> {
+    const ids = new Set<number>();
+    const { trackingGroupId, pausedGroupId, supportsPause, programId } = this.config;
+
+    if (trackingGroupId) {
+      const now = nowCentral();
+      const groupIds = [trackingGroupId];
+      if (supportsPause && pausedGroupId) groupIds.push(pausedGroupId);
+      const rows = await this.mp.getTableRecords<{ Participant_ID: number }>({
+        table: 'Group_Participants',
+        select: 'Participant_ID',
+        filter: `Group_ID IN (${sanitizeIds(groupIds)}) AND (End_Date IS NULL OR End_Date >= '${now}')`,
+      });
+      for (const r of rows) ids.add(r.Participant_ID);
+      return ids;
+    }
+
+    // Milestone-discovery mode: participants holding any of this tool's milestones
+    // within the configured program (mirrors getParticipantsFromMilestones).
+    const milestoneIds = this.config.milestones.map(m => m.milestoneId);
+    if (this.config.pauseMilestoneId) milestoneIds.push(this.config.pauseMilestoneId);
+    if (milestoneIds.length === 0) return ids;
+    for (let i = 0; i < milestoneIds.length; i += BATCH_SIZE) {
+      const batch = milestoneIds.slice(i, i + BATCH_SIZE);
+      const rows = await this.mp.getTableRecords<{ Participant_ID: number }>({
+        table: 'Participant_Milestones',
+        select: 'Participant_ID',
+        filter: `Milestone_ID IN (${sanitizeIds(batch)}) AND Program_ID = ${programId}`,
+      });
+      for (const r of rows) ids.add(r.Participant_ID);
+    }
+    return ids;
+  }
+
+  /** Throw/report (per F2_SCOPE_ENFORCEMENT) if the participant is not in tool scope. */
+  private async assertParticipantInScope(participantId: number): Promise<void> {
+    const scoped = await this.getScopedParticipantIds();
+    enforceScope(scoped.has(participantId), `participant ${participantId} outside this journey tool`);
+  }
+
+  /** Resolve a Group_Participant record to its Participant_ID, then assert scope. */
+  private async assertGroupParticipantInScope(groupParticipantId: number): Promise<void> {
+    const rows = await this.mp.getTableRecords<{ Participant_ID: number }>({
+      table: 'Group_Participants',
+      select: 'Participant_ID',
+      filter: `Group_Participant_ID = ${sanitizeId(groupParticipantId)}`,
+      top: 1,
+    });
+    if (!rows[0]) { enforceScope(false, `group-participant ${groupParticipantId} not found`); return; }
+    await this.assertParticipantInScope(rows[0].Participant_ID);
+  }
+
+  /** Resolve a Participant_Milestone record to its Participant_ID, then assert scope. */
+  private async assertMilestoneRecordInScope(participantMilestoneId: number): Promise<void> {
+    const rows = await this.mp.getTableRecords<{ Participant_ID: number }>({
+      table: 'Participant_Milestones',
+      select: 'Participant_ID',
+      filter: `Participant_Milestone_ID = ${sanitizeId(participantMilestoneId)}`,
+      top: 1,
+    });
+    if (!rows[0]) { enforceScope(false, `milestone ${participantMilestoneId} not found`); return; }
+    await this.assertParticipantInScope(rows[0].Participant_ID);
   }
 
   /**
@@ -161,11 +237,10 @@ export class JourneyProcessingService {
     contactId = sanitizeId(contactId);
     participantId = sanitizeId(participantId);
     groupParticipantId = groupParticipantId == null ? null : sanitizeId(groupParticipantId);
-    // SECURITY TODO(F2): per-record authorization. requireFeatureAccess only verifies
-    // the user may use this journey feature, not that this specific participant is in
-    // scope for it. A user with access to one journey could read another participant's
-    // detail by passing a different (valid) ID. Verify participantId/contactId belongs
-    // to this tool's tracking group/program before returning PII. Tracked follow-up.
+    // SECURITY (F2): per-record authorization. requireFeatureAccess only proves the
+    // user may use this journey tool, not that this participant belongs to it — so
+    // verify the participant is in this tool's scope before returning any PII.
+    await this.assertParticipantInScope(participantId);
     const contacts = await this.mp.getTableRecords<ContactRecord>({
       table: 'Contacts',
       select: 'Contact_ID,First_Name,Nickname,Last_Name,dp_fileUniqueId AS Image_GUID,Email_Address,Mobile_Phone',
@@ -260,6 +335,9 @@ export class JourneyProcessingService {
       throw new Error('Complete requires a tracking group');
     }
 
+    // SECURITY (F2): the group-participant record must belong to this tool.
+    await this.assertGroupParticipantInScope(currentGroupParticipantId);
+
     const now = nowCentral();
     await this.mp.updateTableRecords(
       'Group_Participants',
@@ -279,6 +357,8 @@ export class JourneyProcessingService {
     Date_Accomplished?: string;
     Notes?: string;
   }, userId?: number): Promise<number> {
+    // SECURITY (F2): only write milestones for participants this tool manages.
+    await this.assertParticipantInScope(data.Participant_ID);
     // Check if this milestone is configured to discontinue the journey
     const milestoneConfig = this.config.milestones.find(m => m.milestoneId === data.Milestone_ID);
     const discontinueJourney = milestoneConfig?.discontinuesJourney === true;
@@ -309,6 +389,8 @@ export class JourneyProcessingService {
     Date_Accomplished?: string;
     Notes?: string;
   }, userId?: number): Promise<void> {
+    // SECURITY (F2): the milestone record must belong to a participant in this tool.
+    await this.assertMilestoneRecordInScope(data.Participant_Milestone_ID);
     const record: Record<string, unknown> = {
       Participant_Milestone_ID: data.Participant_Milestone_ID,
     };
@@ -335,6 +417,8 @@ export class JourneyProcessingService {
     }
 
     const { participantId, currentGroupParticipantId, notes, userId } = params;
+    // SECURITY (F2): only pause participants this tool manages.
+    await this.assertParticipantInScope(participantId);
     const { pausedGroupId, pauseMilestoneId, programId, defaultGroupRoleId } = this.config;
 
     if (!pausedGroupId || !pauseMilestoneId || !programId || !defaultGroupRoleId) {
@@ -379,6 +463,8 @@ export class JourneyProcessingService {
     }
 
     const { participantId, currentGroupParticipantId, userId } = params;
+    // SECURITY (F2): only resume participants this tool manages.
+    await this.assertParticipantInScope(participantId);
     const { trackingGroupId, defaultGroupRoleId } = this.config;
 
     if (!trackingGroupId || !defaultGroupRoleId) {


### PR DESCRIPTION
## Summary

Closes **F2** (HIGH) from the [2026-06-23 audit](.claude/notes/security-audit-2026-06-23.md) — per-record participant scope authorization in journey/compliance. **Stacked on #185** (base = `security/idor-injection-redirect-hardening`).

> ⚠️ **Needs runtime verification before relying on enforce mode.** The scope queries mirror the discovery logic, but boundary cases (active-date edges, milestone-mode timing) could surface false denials. **Deploy in `report` mode first**, exercise the tools, and watch logs for `[scope:report]` lines — then flip to enforce.

## The problem

`requireFeatureAccess` only proves a user may *use* a tool, not that a given participant *belongs* to it. So a user of one journey/compliance tool could read or write **another** tool's participants by passing a different (valid) ID — cross-tool PII read (incl. background-check/compliance data) and cross-participant writes.

## The fix

Each service resolves the set of `Participant_ID`s it legitimately manages — `getScopedParticipantIds()`, mirroring the `getParticipants()` discovery filters (tracking + paused group membership; or milestone-program / group-role discovery) — and gates every per-record entry point:

| Path | Guard |
|------|-------|
| `getParticipantDetail` (read) | participant in scope |
| `createMilestone`, `createCertification` | `data.Participant_ID` in scope |
| `updateMilestone` | milestone record → participant in scope |
| `createFormResponse` | contact → participant in scope |
| `completeParticipant` | group-participant record → participant in scope |
| `pauseParticipant`, `resumeParticipant` | participant in scope |

### Rollout toggle — `src/lib/scope-enforcement.ts`
`F2_SCOPE_ENFORCEMENT` env var:
- unset / `enforce` (default): out-of-scope → throws `Forbidden`.
- `report`: logs `[scope:report] would deny …` and **allows** — for safe validation against real data.

## Trade-offs / notes
- Adds one lightweight `Group_Participants`/`Participant_Milestones` ID query per gated op (resolving the scope set). Watch latency for very large tracking groups; `report` mode lets you measure before enforcing.
- **Still open within F2:** Zod schema validation on the create/update writes (defense-in-depth, separate from the scope gate).
- `pauseParticipant` is doubly covered (its internal `createMilestone` also asserts) — harmless.

## Validation
- ✅ `npm run test:run` — **523 passing** (incl. new `scope-enforcement` tests)
- ✅ `npm run lint` — clean
- ℹ️ `npx tsc --noEmit` — 16 errors, all pre-existing test-fixture issues, unchanged; none in changed files.
- ℹ️ Service-layer scope logic is **not** unit-tested (these services have no test harness today) — hence the runtime/report-mode validation guidance above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PJ9LNFjCq2MDCREYQZcDE
