### PR TITLE
fix(auth): repair better-auth 1.6 session integrity (userGuid/mpUserId/mpContactId)

### DIFF
--- a/.claude/notes/upstream-sync-log.md
+++ b/.claude/notes/upstream-sync-log.md
@@ -11,6 +11,24 @@ git log main..upstream/main --oneline
 
 Or review PRs at: https://github.com/MinistryPlatform-Community/MPNext/pulls
 
+## Review: 2026-07-10
+
+Reviewed upstream PRs #56–#66 (all merged upstream since the 2026-04-08 review). Our fork already leads or matches upstream on security/timezone/audit work, so only the better-auth 1.6 session-integrity fix (PR #66) was genuinely needed.
+
+| PR | Title | Action | Notes |
+|----|-------|--------|-------|
+| #56 | VS Code Peacock color settings | Skipped | Personal editor settings, not app code |
+| #57 | Sanitize filter parameters (injection) | Already incorporated | We already have `sanitizeFilterValue`/`sanitizeIds`/`sanitizeIdsOptional`/`sanitizeId`/`sanitizeGuid` in `filter-sanitize.ts` + CI security-lint. Authored upstream by jonnydcakes; our fork pioneered this |
+| #59 | Resolve npm audit vulnerabilities | Already incorporated | Our deps already patched via PR #191 + prior audits; `npm audit` shows only 1 moderate (transitive `brace-expansion` under `@typescript-eslint`) |
+| #60 | React 19 Suspense refactor + template tool removal | Skipped (divergent) | Upstream's user-context/contact-lookup Suspense refactor and template-tool removal target their architecture; our fork uses `UserProvider`/PPR patterns that have diverged. Not ported — revisit if we touch those areas |
+| #61 | Expand filter sanitization to remaining GUID sites + LIKE wildcards | Already incorporated | We already have `sanitizeLikeValue()` (neutralizes `%` `_` `[` wildcards) and sanitize all GUID sites |
+| #62 | MP query syntax reference doc | Skipped (optional) | Documentation only; we have our own MP REST notes in CLAUDE.md. Low value to port |
+| #63 | Contact-logs timezone handling on Contact_Date | Already incorporated | We have `isoToCentralSql()` (America/Chicago) in `contactLogService.ts` — see CLAUDE.md "Timezone Handling" |
+| #64 | Attribute MP writes to acting user via session context | Already incorporated | We already thread `$userId` through service writes (21+ call sites) for audit attribution |
+| #66 | **Better Auth 1.6 session-integrity repair** | **Incorporated** | **Live bug in our fork.** better-auth 1.6's `parseAdditionalUserInputFromProviderProfile` strips additional fields declared `input: false` before user creation. Our `userGuid`/`mpUserId`/`mpContactId` were all `input: false` and populated server-side → all three dropped on login (blank avatar, dead user menu, `userId: null`, broken `$userId` audit). Adapted upstream's userGuid-only fix to all **three** of our fields; extracted `userAdditionalFields` const with warning comment; added `/session-error` recovery route + `AuthWrapper` guard; added `src/lib/auth.test.ts` + `auth-wrapper.test.tsx` guards. Upstream also moved to lazy `resolveMpUserId` in customSession — we kept our stored-field approach (less divergence) |
+
+Deps note: PR #66 also bundled a lockfile security refresh (undici, vite, esbuild, js-yaml, etc.) which we largely already have. The 1 remaining moderate (`brace-expansion` GHSA-jxxr-4gwj-5jf2, transitive dev-only under `@typescript-eslint`) is deferred — `npm audit fix` resolves it but it's not runtime-exploitable.
+
 ## Last Review: 2026-04-08
 
 Reviewed all open/merged upstream PRs through PR #55. Status:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,14 +34,16 @@ This guide provides essential information for AI assistants (like Claude) workin
 
 - **Framework**: Next.js 16 (App Router, Turbopack, Cache Components/PPR) with React 19, TypeScript strict mode
 - **Ministry Platform Integration**: Custom provider at `src/lib/providers/ministry-platform/` with REST API client, auth, and type-safe models
-- **Auth**: Better Auth (`better-auth@^1.4`) with Ministry Platform OAuth via `genericOAuth` plugin (`src/lib/auth.ts`)
+- **Auth**: Better Auth (`better-auth@^1.6`) with Ministry Platform OAuth via `genericOAuth` plugin (`src/lib/auth.ts`)
   - **Server Config**: `src/lib/auth.ts` — `betterAuth()` with `genericOAuth`, `customSession`, `nextCookies()` plugins
   - **Client Config**: `src/lib/auth-client.ts` — `createAuthClient()` with matching client plugins
   - **Auth Helpers**: `src/lib/auth-helpers.ts` — `getSession()`, `requireSession()`, `getMpUserId()`, `getUserGuid()` for server actions
   - **Route Handler**: `src/app/api/auth/[...all]/route.ts` — Better Auth API route
   - **Route Protection**: `src/proxy.ts` — Next.js 16 proxy with session cookie validation via `getSessionCookie` from `better-auth/cookies`
   - **Session Strategy**: JWT cookie-based sessions; no per-user OIDC tokens stored — services use client credentials (`MPHelper` singleton) with `$userId` for audit attribution
-  - **User Fields**: `additionalFields` on user model: `userGuid`, `mpUserId`, `mpContactId` — populated at login via `getUserInfo` callback
+  - **User Fields**: `additionalFields` on user model (exported as `userAdditionalFields`): `userGuid`, `mpUserId`, `mpContactId` — populated server-side at login via `getUserInfo`/`mapProfileToUser`
+    - **MANDATORY `input: true`**: All three fields MUST keep `input: true`. As of better-auth 1.6, `parseAdditionalUserInputFromProviderProfile` strips any additional field declared `input: false` before the user record is created — silently dropping our server-populated fields (breaks avatar/user menu, `getUserGuid()`, and `$userId` audit attribution). Guarded by `src/lib/auth.test.ts`. Do NOT flip these back to `input: false`.
+  - **Session recovery**: If a session somehow lacks `userGuid`, `AuthWrapper` redirects to `/session-error` (a minimal recovery page with a sign-out button that lives outside the `(web)` route group so it can't redirect-loop) instead of rendering a dead app with no sign-out control.
   - **OIDC Logout**: Implements RP-initiated logout flow to properly end Ministry Platform OAuth sessions
   - **Required Environment Variables**: `MINISTRY_PLATFORM_BASE_URL`, `BETTER_AUTH_URL`, `BETTER_AUTH_SECRET`
   - **MP OAuth Setup**: Requires Post-Logout Redirect URIs configured in Ministry Platform OAuth client (see README.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -4756,9 +4756,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/app/session-error/page.tsx
+++ b/src/app/session-error/page.tsx
@@ -1,0 +1,35 @@
+import { handleSignOut } from "@/components/user-menu/actions";
+
+/**
+ * Recovery page for authenticated-but-unusable sessions.
+ *
+ * `AuthWrapper` redirects here when a session exists but has no `userGuid`
+ * (the MP User_GUID). Such a session can't load an MP profile, so the header
+ * avatar/menu — and therefore the normal sign-out control — never render.
+ * This page gives the user an unconditional way out via `handleSignOut`.
+ *
+ * It lives outside the (web) route group, so it is NOT wrapped by AuthWrapper
+ * and cannot cause a redirect loop.
+ */
+export default function SessionErrorPage() {
+  return (
+    <div className="flex items-center justify-center min-h-screen px-4">
+      <div className="max-w-md text-center">
+        <h1 className="text-2xl font-semibold mb-3">We couldn&apos;t load your account</h1>
+        <p className="text-gray-600 mb-6">
+          Your sign-in completed, but it didn&apos;t include the Ministry Platform
+          user link we need to load your profile. Please sign out and sign in
+          again. If this keeps happening, contact your administrator.
+        </p>
+        <form action={handleSignOut}>
+          <button
+            type="submit"
+            className="inline-flex items-center justify-center rounded-md bg-[#344767] px-5 py-2.5 text-white font-medium hover:bg-[#2d3a5f] focus:outline-none focus:ring-2 focus:ring-blue-300"
+          >
+            Sign out and try again
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/auth-wrapper.test.tsx
+++ b/src/components/layout/auth-wrapper.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * AuthWrapper guard tests.
+ *
+ * AuthWrapper is the server-side auth guard for the (web) route group. It must:
+ * - redirect unauthenticated requests to /signin
+ * - redirect authenticated-but-broken sessions (no userGuid) to /session-error,
+ *   so a user whose session lacks a userGuid still has a way to sign out. This
+ *   is the safety net behind the better-auth 1.6 userGuid regression — see
+ *   src/lib/auth.test.ts and the userAdditionalFields comment in src/lib/auth.ts.
+ * - render children for healthy sessions
+ */
+
+const { mockGetSession, mockRedirect } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  // Mirror next/navigation's redirect(), which halts execution by throwing.
+  mockRedirect: vi.fn((url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  }),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: { api: { getSession: mockGetSession } },
+}));
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => new Headers()),
+}));
+vi.mock("next/navigation", () => ({
+  redirect: mockRedirect,
+}));
+
+import { AuthWrapper } from "./auth-wrapper";
+
+describe("AuthWrapper", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("redirects to /signin when there is no session", async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    await expect(AuthWrapper({ children: null })).rejects.toThrow("REDIRECT:/signin");
+    expect(mockRedirect).toHaveBeenCalledWith("/signin");
+  });
+
+  it("redirects to /session-error when the session has no userGuid", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: "ba-internal-id", name: "No Guid", email: "x@example.com" },
+    });
+
+    await expect(AuthWrapper({ children: null })).rejects.toThrow(
+      "REDIRECT:/session-error",
+    );
+    expect(mockRedirect).toHaveBeenCalledWith("/session-error");
+  });
+
+  it("redirects to /session-error when userGuid is null", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: "ba-internal-id", userGuid: null },
+    });
+
+    await expect(AuthWrapper({ children: null })).rejects.toThrow(
+      "REDIRECT:/session-error",
+    );
+  });
+
+  it("renders children when the session has a userGuid", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: "ba-internal-id", userGuid: "ab12cd34-ef56-7890-abcd-ef1234567890" },
+    });
+
+    const result = await AuthWrapper({ children: "CONTENT" });
+
+    expect(mockRedirect).not.toHaveBeenCalled();
+    expect(result).toBeTruthy();
+  });
+});

--- a/src/components/layout/auth-wrapper.tsx
+++ b/src/components/layout/auth-wrapper.tsx
@@ -11,5 +11,17 @@ export async function AuthWrapper({ children }: { children: React.ReactNode }) {
     redirect("/signin");
   }
 
+  // A session without a userGuid is unusable: every MP lookup keys off userGuid,
+  // and without it the header avatar/menu never renders — which leaves the user
+  // with no way to even sign out (the trap behind the better-auth 1.6 regression;
+  // see userAdditionalFields in @/lib/auth). Route these broken sessions to a
+  // recovery page that CAN sign them out, rather than rendering a dead app.
+  // /session-error lives outside the (web) route group, so it is not wrapped by
+  // AuthWrapper and cannot redirect-loop.
+  const userGuid = (session.user as { userGuid?: string | null }).userGuid;
+  if (!userGuid) {
+    redirect("/session-error");
+  }
+
   return <>{children}</>;
 }

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { parseAdditionalUserInputFromProviderProfile } from "better-auth/db";
+import { userAdditionalFields } from "@/lib/auth";
+
+/**
+ * Auth field-config guard.
+ *
+ * Regression guard for the better-auth 1.6 upgrade incident (upstream MPNext
+ * PR #66; our better-auth bump to ^1.6.23 in PR #191).
+ *
+ * As of better-auth 1.6, `parseAdditionalUserInputFromProviderProfile` strips
+ * any user additional field declared with `input: false` BEFORE the user record
+ * is created (`better-auth/dist/db/schema` — `if (schema[key]?.input === false)
+ * continue;`). Our `userGuid`, `mpUserId`, and `mpContactId` are all populated
+ * server-side from the OAuth profile via `mapProfileToUser`, so `input: false`
+ * silently dropped them — leaving the session with `userGuid`/`mpUserId`/
+ * `mpContactId` undefined and breaking MP profile lookups (avatar, user menu,
+ * User_ID resolution) and audit attribution (`$userId`).
+ *
+ * These tests run the REAL better-auth field-filtering function against our REAL
+ * field config, so they fail if either (a) someone flips a field back to
+ * `input: false`, or (b) a future better-auth upgrade changes how
+ * provider-profile fields are parsed.
+ */
+describe("userAdditionalFields", () => {
+  it("declares userGuid, mpUserId, and mpContactId with input:true", () => {
+    for (const field of ["userGuid", "mpUserId", "mpContactId"] as const) {
+      expect(userAdditionalFields[field]).toBeDefined();
+      // input:true is mandatory — see the comment in src/lib/auth.ts.
+      expect(userAdditionalFields[field].input).toBe(true);
+    }
+  });
+
+  it("persists all three fields from the OAuth provider profile (better-auth 1.6 guard)", () => {
+    const guid = "ab12cd34-ef56-7890-abcd-ef1234567890";
+    const options = { user: { additionalFields: userAdditionalFields } };
+
+    // Mirrors the object better-auth builds from `mapProfileToUser`'s return
+    // before creating the user record.
+    const parsed = parseAdditionalUserInputFromProviderProfile(
+      options,
+      { userGuid: guid, mpUserId: 42, mpContactId: 99 },
+      "create",
+    );
+
+    expect(parsed).toHaveProperty("userGuid", guid);
+    expect(parsed).toHaveProperty("mpUserId", 42);
+    expect(parsed).toHaveProperty("mpContactId", 99);
+  });
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -8,6 +8,30 @@ import { sanitizeGuid } from "@/lib/providers/ministry-platform/utils/filter-san
 const mpBaseUrl = process.env.MINISTRY_PLATFORM_BASE_URL;
 const mpOauthUrl = `${mpBaseUrl}/oauth`;
 
+/**
+ * Custom fields added to the Better Auth `user` record.
+ *
+ * ALL of these fields MUST keep `input: true`. They are populated server-side
+ * from the OAuth profile via `mapProfileToUser` below (never from a user-facing
+ * form). As of better-auth 1.6, `parseAdditionalUserInputFromProviderProfile`
+ * (better-auth/dist/db/schema — `if (schema[key]?.input === false) continue;`)
+ * strips any additional field declared with `input: false` BEFORE the user
+ * record is created. With `input: false`:
+ *   - `userGuid` is dropped -> every MP profile lookup breaks (blank avatar,
+ *     dead user menu, `userId: null`, and the session gets trapped — see the
+ *     /session-error recovery route in AuthWrapper).
+ *   - `mpUserId` is dropped -> audit attribution (`$userId`) on MP writes breaks.
+ *   - `mpContactId` is dropped -> contact-scoped lookups break.
+ * Since genericOAuth is the only sign-in path and no form sets these fields,
+ * allowing input carries no practical risk. `src/lib/auth.test.ts` guards this
+ * against future regressions. (Ported from upstream MPNext PR #66.)
+ */
+export const userAdditionalFields = {
+  userGuid: { type: "string" as const, required: false, input: true },
+  mpUserId: { type: "number" as const, required: false, input: true },
+  mpContactId: { type: "number" as const, required: false, input: true },
+};
+
 export const auth = betterAuth({
   baseURL: process.env.BETTER_AUTH_URL || "http://localhost:3000",
   secret: process.env.BETTER_AUTH_SECRET,
@@ -21,11 +45,7 @@ export const auth = betterAuth({
   },
 
   user: {
-    additionalFields: {
-      userGuid: { type: "string", required: false, input: false },
-      mpUserId: { type: "number", required: false, input: false },
-      mpContactId: { type: "number", required: false, input: false },
-    },
+    additionalFields: userAdditionalFields,
   },
 
   plugins: [


### PR DESCRIPTION
## Summary

Repairs a **live auth regression** introduced when we bumped `better-auth` to `^1.6.23` (PR #191). As of better-auth 1.6, `parseAdditionalUserInputFromProviderProfile` strips any user `additionalField` declared `input: false` **before** the user record is created:

```js
// better-auth/dist/db/schema.mjs:120
if (schema[key]?.input === false) continue;
```

Our `userGuid`, `mpUserId`, and `mpContactId` were all `input: false` and populated server-side via `mapProfileToUser`, so **all three were silently dropped on every login** since PR #191 merged. Effects:

- `session.user.userGuid` undefined → blank header avatar, dead user menu, `getUserGuid()` returns undefined, `userId: null`
- `session.user.mpUserId` undefined → broken `$userId` audit attribution on MP writes
- `session.user.mpContactId` undefined → broken contact-scoped lookups

Ported and adapted from **upstream MPNext PR #66**. Upstream only had `userGuid`; our fork stores three server-populated fields, so all three are flipped to `input: true`. (Upstream also moved to lazy `resolveMpUserId` in `customSession` — we kept our stored-field approach to minimize divergence.)

## Changes

- **`src/lib/auth.ts`** — extract exported `userAdditionalFields` const with a warning comment; flip `userGuid`/`mpUserId`/`mpContactId` to `input: true`.
- **`src/components/layout/auth-wrapper.tsx`** — redirect sessions missing `userGuid` to `/session-error` (in addition to `/signin` for no session), so an unusable session always has a sign-out path.
- **`src/app/session-error/page.tsx`** — new recovery page with a sign-out button; lives outside the `(web)` route group so it can't redirect-loop.
- **`src/lib/auth.test.ts`** — guards `input: true` by running the **real** better-auth field parser against our real config (fails if a field is flipped back, or if a future better-auth upgrade changes parsing).
- **`src/components/layout/auth-wrapper.test.tsx`** — covers all three guard branches (no session → `/signin`; no `userGuid` → `/session-error`; healthy → renders children).
- **`CLAUDE.md`** / **`.claude/notes/upstream-sync-log.md`** — document the `input: true` requirement + the recovery flow, and log the #56–#66 upstream review.

## Upstream sync (PRs #56–#66)

This is also the periodic upstream review. Our fork already leads or matches upstream on everything else, so #66 was the only genuinely-needed change:

| PR | Action |
|----|--------|
| #56 Peacock colors | Skipped (editor settings) |
| #57 / #61 filter sanitization | Already have (incl. `sanitizeLikeValue`) |
| #59 npm audit | Already patched (PR #191) |
| #60 React Suspense refactor / template removal | Skipped (architecture diverged) |
| #62 MP query syntax doc | Skipped (optional) |
| #63 contact-logs timezone | Already have (`isoToCentralSql`) |
| #64 `$userId` audit attribution | Already have |
| #66 **auth session-integrity** | **This PR** |

## Verification

- `npm run test:run` → **539 passed** (35 files), including 6 new auth tests
- `npm run build` → passes (type check clean); `/session-error` renders as a static route outside `(web)`

## Security Review

Reviewed against `.claude/rules/security.md` and the pre-PR checklist:
- **Auth**: `input: true` re-enables writing these fields, but genericOAuth is the only sign-in path and no user-facing form sets them — values still come solely from server-side `mapProfileToUser` (OAuth `sub` + `dp_Users` lookup). No new client-controllable field surface. Improves security posture by restoring `$userId` audit attribution.
- **Filter safety**: No `filter:` changes. Existing `sanitizeGuid()` on `profile.sub` unchanged.
- **PII/logging**: No new logging; recovery page contains no PII.
- **Redirects**: `/session-error` is a static internal path (no user-supplied URLs).
- **MP writes**: None in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017782ukoZyKnavtiMwa3DPS