### PR TITLE
chore(ci): verify Dependabot PRs instead of skipping them wholesale

### DIFF
--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -56,6 +56,26 @@ The CI workflow includes a `security-lint` job that greps for `.join(` near `fil
 
 If you need `.join()` in a non-filter context and it triggers a false positive, add a `// filter-safety-ignore` comment on the same line.
 
+### CI Job Layout
+
+`.github/workflows/docker-build-push.yml` has three jobs, split by whether they need repository secrets:
+
+| Job | Secrets? | Runs for Dependabot? | What it does |
+|-----|----------|----------------------|--------------|
+| `security-lint` | no | yes | the `.join()` filter grep above |
+| `verify` | no | **yes** | `npm ci`, `npm audit --audit-level=high`, `npm run lint`, `npm run test:run`, `npm run build`, local Docker build (`push: false`), Trivy scan |
+| `build-scan-and-push` | **yes** | no (`if: github.actor != 'dependabot[bot]'`) | registry login, build + push `:${sha}`, Trivy, retag `:dev` / `:latest` / `:main` |
+
+**Keep verification steps in `verify`, not in `build-scan-and-push`.** Dependabot PRs cannot access
+Actions secrets, so the registry job is gated on the actor — and before `verify` existed, that gate
+skipped `npm audit`, the build and the image scan for every bot PR (they merged on `security-lint`
+alone, in ~10s). Anything that does not need the registry belongs in `verify` so it covers all actors.
+
+**`npm audit --audit-level=high` is a hard deploy gate.** It runs before any image is built, so an
+unresolved HIGH advisory blocks *all* deploys, not just dependency PRs. This has bitten twice
+(2026-07-10 after #190, and a 27-day production freeze discovered 2026-08-06). Run it locally before
+pushing.
+
 ## File Upload Validation
 
 All file upload endpoints must validate MIME type **and** file size on the server side. Limits match Ministry Platform: **20 MB max**, standard file formats (PNG, JPG, BMP, GIF, PDF, TXT, CSV):

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -41,16 +41,73 @@ jobs:
       # code. Those sinks are guarded at the service boundary via sanitizeId/sanitizeIds
       # (see .claude/rules/security.md) and code review instead.
 
-  build-scan-and-push:
+  # Everything that does NOT need repository secrets. Runs for every actor,
+  # including dependabot[bot] — which is the point: until this job existed,
+  # `build-scan-and-push` was skipped wholesale for Dependabot (see #152), so
+  # bot PRs merged with no npm audit, no build, no tests and no image scan.
+  # Nothing here touches the registry, so there is no reason to gate it.
+  verify:
     needs: security-lint
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Audit npm dependencies
         run: npm audit --audit-level=high
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Tests
+        run: npm run test:run
+
+      - name: Build
+        run: npm run build
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image locally (no push — no secrets needed)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: mp-charts:ci-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan image
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: 'mp-charts:ci-${{ github.sha }}'
+          format: 'table'
+          exit-code: '1'  # Fail on CRITICAL/HIGH
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+
+  # Registry login + push. This is the only part that needs secrets, and
+  # Dependabot PRs cannot access them, so the actor gate stays here.
+  build-scan-and-push:
+    needs: verify
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
Stacked on #194 — **base is `fix/deps-security-2026-08`, not `main`.** The new `verify` job runs `npm audit --audit-level=high`, which does not pass on current `main`. Retarget to `main` once #194 merges.

## The gap

#152 added `if: github.actor != 'dependabot[bot]'` to `build-scan-and-push` for a real reason:

> *"Dependabot PRs don't have access to repo secrets, so the Docker login step always fails. Skip the job entirely for Dependabot — the build still runs when the PR merges to main."*

Correct diagnosis, over-broad fix. Skipping the *whole* job also dropped `npm audit`, the Docker build and the Trivy image scan — none of which need secrets. Dependabot PRs merge on `security-lint` alone. #193 is the live example: it finished in **10 seconds**, never built, never scanned. Human branches take 1m44s–3m21s.

## The split

| Job | Secrets? | Dependabot? | Does |
|---|---|---|---|
| `security-lint` | no | yes | the `.join()` filter grep (unchanged) |
| **`verify`** (new) | **no** | **yes** | `npm ci`, `npm audit --audit-level=high`, `lint`, `test:run`, `build`, local Docker build (`push: false`), Trivy |
| `build-scan-and-push` | yes | no — **gate kept** | registry login, build + push, Trivy, tag `:dev`/`:latest`/`:main` |

`npm audit` moves out of `build-scan-and-push` into `verify`. Trivy deliberately stays in **both**: `verify` scans the local build (so bot PRs get scanned), `build-scan-and-push` scans the artifact actually pushed to the registry. The local build uses GHA cache so it doesn't contend for the registry buildcache.

The actor gate stays exactly where the secrets are. The alternative — putting `GITLAB_DEPLOY_*` into the separate Dependabot secrets store — would work, but there's no reason to hand registry-push credentials to bot PRs.

## Tests now run in CI for the first time

The workflow had exactly two jobs and neither ran `npm run test:run`. It has only ever been a local gate. 539 tests now run on every push.

## Also documented

Added a CI job-layout table to `.claude/rules/security.md`, including that **`npm audit` is a hard deploy gate** — it runs before any image is built, so an unresolved HIGH blocks *every* deploy, not just dependency PRs. That has now caused two incidents: the 2026-07-10 failure after #190, and the 27-day production freeze found on 2026-08-06.

## Test plan

Validated the YAML and job graph locally (`js-yaml` parse + `needs`/`if` inspection). Real proof is this PR's own run: `verify` should execute and pass. The end-to-end proof is the next Dependabot PR getting a full green build instead of a 10-second skip.

## Security Review

- **Files reviewed**: 2 — `.github/workflows/docker-build-push.yml`, `.claude/rules/security.md`.
- **Issues found**: none.
- **Checklist**: no application code touched. No `filter:` interpolation, uploads, redirects, server actions, auth or rate limiting changed.
- **Secrets handling**: this is the security-relevant part. `GITLAB_DEPLOY_USERNAME`/`GITLAB_DEPLOY_TOKEN` remain referenced **only** in `build-scan-and-push`, which keeps the `github.actor != 'dependabot[bot]'` gate. The new `verify` job references no secrets and pushes nothing. `pull_request_target` was deliberately **not** used — it would run untrusted PR code with a privileged token.
- **Net effect**: strictly more verification, same secret exposure surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)