### PR TITLE
chore(ci): add CodeQL and split the catch-all Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,11 +17,32 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    # Group minor and patch updates together to reduce PR noise
+    # Cap concurrent PRs so a backlog is visible rather than silently truncated.
+    open-pull-requests-limit: 10
     groups:
-      minor-and-patch:
+      # Security updates get their OWN group, separate from routine version
+      # bumps. Previously a single `patterns: ["*"]` minor-and-patch group
+      # swallowed everything, so a superseding group PR would orphan the
+      # individual security PRs — #150, #169 and #182 all died that way
+      # (#182's closing comment: "js-yaml is no longer updatable, so this is
+      # no longer needed"). Security fixes must not be collateral of a
+      # routine-bump rebase.
+      security:
+        applies-to: security-updates
         patterns:
           - "*"
+
+      # Routine version updates, split prod vs dev so a runtime bump is never
+      # buried in a pile of tooling churn and can be reviewed on its own risk.
+      prod-minor-patch:
+        applies-to: version-updates
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      dev-minor-patch:
+        applies-to: version-updates
+        dependency-type: "development"
         update-types:
           - "minor"
           - "patch"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+# Static analysis for the app source. Complements, but does not replace, the
+# `security-lint` grep in docker-build-push.yml — that check is specific to MP
+# `$filter` injection, which CodeQL has no query for. See .claude/rules/security.md.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, so newly published queries run against unchanged code.
+    - cron: '17 9 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze JavaScript/TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write   # required to upload results
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+          # security-extended adds lower-severity + precision queries on top of
+          # the default suite. This repo handles PII, so the extra recall is
+          # worth the additional noise.
+          queries: security-extended
+
+      # No build step: javascript-typescript uses CodeQL's extractor directly.
+      # `npm run build` would only add ~2 min and Turbopack output is not
+      # analyzed anyway.
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:javascript-typescript


### PR DESCRIPTION
Stacked on #195 (which is stacked on #194). Retarget down the chain as each merges.

## Why 17 alerts piled up

**The catch-all group.** The npm ecosystem had one `minor-and-patch` group with `patterns: ["*"]`, so security updates shared a lane with routine bumps. A superseding group PR then orphans the individual security PRs — that is exactly how **#150, #169 and #182** all closed unmerged. #182's closing comment reads *"js-yaml is no longer updatable, so this is no longer needed"* — it had been hand-applied in #183 instead. Not a rejection, but not a healthy pattern either: it means the bot's own bookkeeping decides whether a security fix survives.

Split into three lanes:

| Group | Scope |
|---|---|
| `security` | `applies-to: security-updates`, all patterns — its own lane |
| `prod-minor-patch` | version-updates, `dependency-type: production` |
| `dev-minor-patch` | version-updates, `dependency-type: development` |

Plus `open-pull-requests-limit: 10` (default is 5) so a backlog is visible rather than silently truncated.

Splitting prod from dev also matters for triage: this sweep had 10 runtime alerts and 7 dev-only ones, and they carry very different urgency — the dev ones never ship, since the runner stage only copies `.next/standalone`.

## CodeQL

The repo has no code scanning at all — `/code-scanning/alerts` returns `no analysis found`. Added `javascript-typescript` with the `security-extended` suite (this app handles PII, so the extra recall is worth the noise), on push/PR to `main` plus a weekly cron so newly published queries run against unchanged code. No build step — the JS/TS extractor doesn't need one.

**CodeQL complements, not replaces, `security-lint`.** There is no CodeQL query for Ministry Platform `$filter` injection, which is this codebase's highest-value custom check. Both stay.

## One thing this PR cannot do

**Secret scanning is disabled** and can only be enabled in the UI: Settings → Code security → Secret Protection → enable *Secret scanning* and *Push protection*. Worth doing — the repo is public, and `.env.example` plus the MP OAuth client-credential pattern make a leaked secret plausible.

## Test plan

Both files validated as YAML locally, and the parsed `updates[]` confirmed to yield exactly the three intended npm groups with the limit applied. Dependabot config changes can't be dry-run; the real proof is the next scheduled run producing separate security / prod / dev PRs. CodeQL proves itself on this PR's own `analyze` job.

## Security Review

- **Files reviewed**: 2 — `.github/dependabot.yml`, `.github/workflows/codeql.yml` (new).
- **Issues found**: none.
- **Checklist**: no application code touched; no `filter:`, upload, redirect, server-action, auth or rate-limiting changes.
- **Permissions**: the CodeQL job requests the documented minimum — `security-events: write` (to upload results), `contents: read`, `actions: read`. No secrets referenced. Triggers are `push`/`pull_request` on `main` plus cron; `pull_request_target` deliberately not used.
- **Net effect**: strictly more scanning coverage, no new secret exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)